### PR TITLE
Add `__post_init__` validation for exact SymPy `ImmutableDenseMatrix` (`basis`, `rep`, `M`)

### DIFF
--- a/src/pyhilbert/basis_transform.py
+++ b/src/pyhilbert/basis_transform.py
@@ -8,7 +8,7 @@ from typing import Tuple, cast, Literal
 import numpy as np
 
 from .abstracts import Functional
-from .utils import FrozenDict, matchby
+from .utils import FrozenDict, matchby, validate_matrix
 from .spatials import Lattice, ReciprocalLattice, Offset, Momentum, AffineSpace
 from .hilbert import MomentumSpace, brillouin_zone, hilbert, HilbertSpace
 from .tensors import Tensor, mapping_matrix
@@ -22,6 +22,7 @@ class BasisTransform(Functional):
     def __post_init__(self):
         if self.M.det() == 0:
             raise ValueError("M must have non-zero determinant")
+        validate_matrix(self.M, "BasisTransform.M")
 
 
 @lru_cache

--- a/src/pyhilbert/spatials.py
+++ b/src/pyhilbert/spatials.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from .precision import get_precision_config
 from sympy import ImmutableDenseMatrix, sympify
-from .utils import FrozenDict
+from .utils import FrozenDict, validate_matrix
 from .abstracts import Operable, HasDual, HasBase, Plottable
 
 
@@ -25,7 +25,8 @@ class Spatial(Operable, Plottable, ABC):
 class AffineSpace(Spatial):
     basis: ImmutableDenseMatrix
 
-    # TODO __post_init__ to validate basis is rational / int
+    def __post_init__(self):
+        validate_matrix(self.basis, "AffineSpace.basis")
 
     @property
     def dim(self) -> int:
@@ -171,6 +172,7 @@ class Offset(Spatial, HasBase[AffineSpace]):
     def __post_init__(self):
         if self.rep.shape != (self.space.dim, 1):
             raise ValueError("Invalid Shape")
+        validate_matrix(self.rep, "Offset.rep")
 
     @property
     def dim(self) -> int:

--- a/src/pyhilbert/utils.py
+++ b/src/pyhilbert/utils.py
@@ -12,7 +12,7 @@ from typing import (
     Type,
     cast,
 )
-from sympy import ImmutableDenseMatrix, Rational, Float
+from sympy import ImmutableDenseMatrix, Float
 import torch
 
 
@@ -199,6 +199,7 @@ def subtypes(cls: Type) -> Tuple[ABCMeta, ...]:
             stack.extend(sub.__subclasses__())
     return cast(Tuple[ABCMeta, ...], tuple(out))
 
+
 def validate_matrix(mat: ImmutableDenseMatrix, name: str = "matrix") -> None:
     """
     Validates that all entries in the matrix are exact SymPy expressions (no Floats).
@@ -207,7 +208,7 @@ def validate_matrix(mat: ImmutableDenseMatrix, name: str = "matrix") -> None:
     for i in range(mat.rows):
         for j in range(mat.cols):
             val = mat[i, j]
-            if getattr(val, 'has', lambda x: False)(Float):
+            if getattr(val, "has", lambda x: False)(Float):
                 raise TypeError(
                     f"Invalid entry in {name} at ({i}, {j}): {val} (type {type(val)}). "
                     "Entries must be exact (no floating-point numbers allowed)."

--- a/src/pyhilbert/utils.py
+++ b/src/pyhilbert/utils.py
@@ -12,6 +12,7 @@ from typing import (
     Type,
     cast,
 )
+from sympy import ImmutableDenseMatrix, Rational, Float
 import torch
 
 
@@ -197,3 +198,17 @@ def subtypes(cls: Type) -> Tuple[ABCMeta, ...]:
             out.add(sub)
             stack.extend(sub.__subclasses__())
     return cast(Tuple[ABCMeta, ...], tuple(out))
+
+def validate_matrix(mat: ImmutableDenseMatrix, name: str = "matrix") -> None:
+    """
+    Validates that all entries in the matrix are exact SymPy expressions (no Floats).
+    Raises TypeError with index information if an invalid entry is found.
+    """
+    for i in range(mat.rows):
+        for j in range(mat.cols):
+            val = mat[i, j]
+            if getattr(val, 'has', lambda x: False)(Float):
+                raise TypeError(
+                    f"Invalid entry in {name} at ({i}, {j}): {val} (type {type(val)}). "
+                    "Entries must be exact (no floating-point numbers allowed)."
+                )

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -1,6 +1,6 @@
 import torch
 import numpy as np
-from sympy import ImmutableDenseMatrix
+from sympy import ImmutableDenseMatrix, Rational
 from pyhilbert.spatials import Lattice, Offset, Momentum
 from pyhilbert.hilbert import hilbert, Mode, brillouin_zone
 from pyhilbert.fourier import fourier_transform
@@ -14,7 +14,7 @@ def test_fourier_kernel_1d():
     recip = lat.dual
 
     # Define K points: 0, 0.25, 0.5, 0.75 (fractional in reciprocal basis)
-    k_reps = [0, 0.25, 0.5, 0.75]
+    k_reps = [0, Rational(1, 4), Rational(1, 2), Rational(3, 4)]
     K = tuple(Momentum(rep=ImmutableDenseMatrix([k]), space=recip) for k in k_reps)
 
     # Define R offsets: 0, 1, 2, 3 (fractional/integer in lattice basis)
@@ -28,7 +28,7 @@ def test_fourier_kernel_1d():
     expected = torch.zeros((4, 4), dtype=torch.complex128)
     for i, k in enumerate(k_reps):
         for j, r in enumerate(r_reps):
-            phase = -2j * np.pi * k * r
+            phase = -2j * np.pi * float(k) * float(r)
             expected[i, j] = np.exp(phase)
 
     assert torch.allclose(ft, expected)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -100,13 +100,13 @@ def test_bandstructure_plot():
     # 1. Define Lattice (2D Square)
     # Basis: [[a, 0], [0, a]]
     a = sy.Symbol("a")
-    basis = sy.ImmutableDenseMatrix([[a, 0.0], [0.0, a]])
+    basis = sy.ImmutableDenseMatrix([[a, 0], [0, a]])
     # Small shape for test speed
     lat = Lattice(basis=basis, shape=(4, 4))
 
     # 2. Define Unit Cell (Bloch Space)
     # Single s-orbital at origin (0,0)
-    r_0 = Offset(rep=sy.ImmutableDenseMatrix([[0.0], [0.0]]), space=lat.affine)
+    r_0 = Offset(rep=sy.ImmutableDenseMatrix([[0], [0]]), space=lat.affine)
     mode_s = Mode.from_attr(count=1, r=r_0, label="s")
     bloch_space = hilbert([mode_s])
 

--- a/tests/test_spatials.py
+++ b/tests/test_spatials.py
@@ -42,7 +42,7 @@ def test_lattice_creation_and_dual():
 
 def test_lattice_with_unit_cell():
     basis = ImmutableDenseMatrix([[1, 0], [0, 1]])
-    unit_cell_input = {"a": (0, 0), "b": (0.5, 0.5)}
+    unit_cell_input = {"a": (0, 0), "b": (sy.Rational(1, 2), sy.Rational(1, 2))}
     lattice = Lattice(basis=basis, shape=(2, 2), unit_cell=unit_cell_input)
 
     assert isinstance(lattice.unit_cell, FrozenDict)
@@ -50,7 +50,7 @@ def test_lattice_with_unit_cell():
     assert isinstance(lattice.unit_cell["a"], Offset)
     assert lattice.unit_cell["a"].rep == ImmutableDenseMatrix([0, 0])
     assert isinstance(lattice.unit_cell["b"], Offset)
-    assert lattice.unit_cell["b"].rep == ImmutableDenseMatrix([0.5, 0.5])
+    assert lattice.unit_cell["b"].rep == ImmutableDenseMatrix([sy.Rational(1, 2), sy.Rational(1, 2)])
 
     # ReciprocalLattice should not accept unit_cell
     with pytest.raises(TypeError):
@@ -105,7 +105,7 @@ def test_coords():
     assert coords.shape == (4, 2)
 
     # Explicit unit cell
-    unit_cell = {"a": (0.1, 0.1)}
+    unit_cell = {"a": (sy.Rational(1, 10), sy.Rational(1, 10))}
     lattice_offset = Lattice(basis=basis, shape=(2, 2), unit_cell=unit_cell)
     coords_offset = lattice_offset.coords()
     assert coords_offset.shape == (4, 2)

--- a/tests/test_spatials.py
+++ b/tests/test_spatials.py
@@ -50,7 +50,9 @@ def test_lattice_with_unit_cell():
     assert isinstance(lattice.unit_cell["a"], Offset)
     assert lattice.unit_cell["a"].rep == ImmutableDenseMatrix([0, 0])
     assert isinstance(lattice.unit_cell["b"], Offset)
-    assert lattice.unit_cell["b"].rep == ImmutableDenseMatrix([sy.Rational(1, 2), sy.Rational(1, 2)])
+    assert lattice.unit_cell["b"].rep == ImmutableDenseMatrix(
+        [sy.Rational(1, 2), sy.Rational(1, 2)]
+    )
 
     # ReciprocalLattice should not accept unit_cell
     with pytest.raises(TypeError):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,66 @@
+import pytest
+from sympy import ImmutableDenseMatrix, Rational, Symbol, Integer
+from pyhilbert.utils import validate_matrix
+from pyhilbert.spatials import AffineSpace, Offset
+from pyhilbert.basis_transform import BasisTransform
+
+def test_validate_matrix_valid():
+    m1 = ImmutableDenseMatrix([[1, 2], [3, 4]])
+    validate_matrix(m1)
+    
+    m2 = ImmutableDenseMatrix([[Rational(1, 2), 3], [4, Rational(5, 3)]])
+    validate_matrix(m2)
+
+def test_validate_matrix_invalid():
+    # Float
+    m1 = ImmutableDenseMatrix([[1.5, 2], [3, 4]])
+    with pytest.raises(TypeError, match="Invalid entry"):
+        validate_matrix(m1)
+        
+    # Symbol
+    x = Symbol('x')
+    m2 = ImmutableDenseMatrix([[x, 2], [3, 4]])
+    validate_matrix(m2)
+
+def test_affine_space_validation():
+    # Valid
+    basis = ImmutableDenseMatrix([[1, 0], [0, 1]])
+    AffineSpace(basis=basis)
+    
+    # Invalid
+    basis_bad = ImmutableDenseMatrix([[1.0, 0], [0, 1]])
+    with pytest.raises(TypeError, match="Invalid entry"):
+        AffineSpace(basis=basis_bad)
+
+def test_offset_validation():
+    basis = ImmutableDenseMatrix([[1, 0], [0, 1]])
+    space = AffineSpace(basis=basis)
+    
+    # Valid
+    rep = ImmutableDenseMatrix([[1], [2]])
+    Offset(rep=rep, space=space)
+    
+    # Invalid Shape
+    rep_bad_shape = ImmutableDenseMatrix([[1, 2]])
+    with pytest.raises(ValueError, match="Invalid Shape"):
+        Offset(rep=rep_bad_shape, space=space)
+        
+    # Invalid Type
+    rep_bad_type = ImmutableDenseMatrix([[1.5], [2]])
+    with pytest.raises(TypeError, match="Invalid entry"):
+        Offset(rep=rep_bad_type, space=space)
+
+def test_basis_transform_validation():
+    # Valid
+    M = ImmutableDenseMatrix([[1, 1], [0, 1]])
+    BasisTransform(M=M)
+    
+    # Invalid Det
+    M_det0 = ImmutableDenseMatrix([[0, 0], [0, 0]])
+    with pytest.raises(ValueError, match="M must have non-zero determinant"):
+        BasisTransform(M=M_det0)
+        
+    # Invalid Type
+    M_bad_type = ImmutableDenseMatrix([[1.5, 1], [0, 1]])
+    with pytest.raises(TypeError, match="Invalid entry"):
+        BasisTransform(M=M_bad_type)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,65 +1,70 @@
 import pytest
-from sympy import ImmutableDenseMatrix, Rational, Symbol, Integer
+from sympy import ImmutableDenseMatrix, Rational, Symbol
 from pyhilbert.utils import validate_matrix
 from pyhilbert.spatials import AffineSpace, Offset
 from pyhilbert.basis_transform import BasisTransform
 
+
 def test_validate_matrix_valid():
     m1 = ImmutableDenseMatrix([[1, 2], [3, 4]])
     validate_matrix(m1)
-    
+
     m2 = ImmutableDenseMatrix([[Rational(1, 2), 3], [4, Rational(5, 3)]])
     validate_matrix(m2)
+
 
 def test_validate_matrix_invalid():
     # Float
     m1 = ImmutableDenseMatrix([[1.5, 2], [3, 4]])
     with pytest.raises(TypeError, match="Invalid entry"):
         validate_matrix(m1)
-        
+
     # Symbol
-    x = Symbol('x')
+    x = Symbol("x")
     m2 = ImmutableDenseMatrix([[x, 2], [3, 4]])
     validate_matrix(m2)
+
 
 def test_affine_space_validation():
     # Valid
     basis = ImmutableDenseMatrix([[1, 0], [0, 1]])
     AffineSpace(basis=basis)
-    
+
     # Invalid
     basis_bad = ImmutableDenseMatrix([[1.0, 0], [0, 1]])
     with pytest.raises(TypeError, match="Invalid entry"):
         AffineSpace(basis=basis_bad)
 
+
 def test_offset_validation():
     basis = ImmutableDenseMatrix([[1, 0], [0, 1]])
     space = AffineSpace(basis=basis)
-    
+
     # Valid
     rep = ImmutableDenseMatrix([[1], [2]])
     Offset(rep=rep, space=space)
-    
+
     # Invalid Shape
     rep_bad_shape = ImmutableDenseMatrix([[1, 2]])
     with pytest.raises(ValueError, match="Invalid Shape"):
         Offset(rep=rep_bad_shape, space=space)
-        
+
     # Invalid Type
     rep_bad_type = ImmutableDenseMatrix([[1.5], [2]])
     with pytest.raises(TypeError, match="Invalid entry"):
         Offset(rep=rep_bad_type, space=space)
 
+
 def test_basis_transform_validation():
     # Valid
     M = ImmutableDenseMatrix([[1, 1], [0, 1]])
     BasisTransform(M=M)
-    
+
     # Invalid Det
     M_det0 = ImmutableDenseMatrix([[0, 0], [0, 0]])
     with pytest.raises(ValueError, match="M must have non-zero determinant"):
         BasisTransform(M=M_det0)
-        
+
     # Invalid Type
     M_bad_type = ImmutableDenseMatrix([[1.5, 1], [0, 1]])
     with pytest.raises(TypeError, match="Invalid entry"):


### PR DESCRIPTION
### Description
Several core dataclasses accept SymPy ImmutableDenseMatrix values without enforcing that entries are exact (Integer/Rational). This allows floats/symbols/irrationals to enter, causing late failures in inversion, substitution, and NumPy/Torch conversion (especially in plotting). Add __post_init__ checks to fail fast with clear errors (bad value + index).

See #47 

### TODO

- [x] Implement exactness validation (Integer/Rational/Symbol only) with informative error messages

- [x] Keep current checks (shape for rep, det != 0 for M) in place