### PR TITLE
Refactor lattice unit cell handling to store positions in fractional coordinate to main branch

### DIFF
--- a/src/qten/geometries/basis_transform.py
+++ b/src/qten/geometries/basis_transform.py
@@ -77,12 +77,8 @@ def lattice_transform(t: BasisTransform, lat: Lattice) -> Lattice:
         for i, k in enumerate(shifts):
             new_frac = M_inv @ (atom_vec + k)
             new_frac = new_frac.applyfunc(lambda x: x - sy.floor(x))
-
-            # Lattice.unit_cell expects Cartesian offsets, not fractional reps.
-            new_offset = ImmutableDenseMatrix(new_basis @ new_frac)
-
             new_label = f"{label}_{i}" if len(shifts) > 1 else label
-            new_unit_cell[new_label] = new_offset
+            new_unit_cell[new_label] = ImmutableDenseMatrix(new_frac)
 
     if not isinstance(lat.boundaries, PeriodicBoundary):
         raise NotImplementedError(

--- a/src/qten/geometries/spatials.py
+++ b/src/qten/geometries/spatials.py
@@ -128,9 +128,7 @@ class Lattice(AbstractLattice["Offset"]):
             Boundary condition defining the periodic region. If omitted,
             `shape` is used to build a `PeriodicBoundary`.
         `unit_cell` : `Mapping[str, ImmutableDenseMatrix] | None`
-            Mapping from site labels to site positions in Cartesian coordinates.
-            Positions are converted and stored internally in fractional
-            coordinates.
+            Mapping from site labels to site positions in fractional coordinates.
         `shape` : `Sequence[int] | None`
             Legacy shorthand for a diagonal periodic boundary.
         """
@@ -166,7 +164,6 @@ class Lattice(AbstractLattice["Offset"]):
             )
 
         processed_cell: dict[str, ImmutableDenseMatrix] = {}
-        basis_inverse = self.basis.inv()
         for site, offset in unit_cell.items():
             if not isinstance(offset, ImmutableDenseMatrix):
                 raise TypeError(
@@ -179,9 +176,7 @@ class Lattice(AbstractLattice["Offset"]):
                     raise ValueError(
                         f"unit_cell['{site}'] has shape {offset.shape}; expected ({self.dim}, 1)."
                     ) from e
-            fractional_offset = basis_inverse @ offset
-            fractional_offset = ImmutableDenseMatrix(fractional_offset)
-            processed_cell[site] = fractional_offset
+            processed_cell[site] = offset
         object.__setattr__(self, "_unit_cell_fractional", FrozenDict(processed_cell))
 
     @property

--- a/tests/test_abelian.py
+++ b/tests/test_abelian.py
@@ -897,10 +897,8 @@ def test_affine_query_c6_rotates_honeycomb_a_to_b_sublattice():
     honeycomb = Lattice(
         basis=triangular,
         unit_cell={
-            "a": triangular
-            @ ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]),
-            "b": triangular
-            @ ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]),
+            "a": ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]),
+            "b": ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]),
         },
         shape=(12, 12),
     )

--- a/tests/test_spatials.py
+++ b/tests/test_spatials.py
@@ -133,10 +133,8 @@ def test_lattice_basis_vectors_use_affine_space_when_not_lattice_sites():
         basis=triangular,
         boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4, 4)),
         unit_cell={
-            "a": triangular
-            @ ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]),
-            "b": triangular
-            @ ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]),
+            "a": ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]),
+            "b": ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]),
         },
     )
 


### PR DESCRIPTION
## Description
Previously, `Lattice.__init__` required users to manually map their fractional sites to Cartesian space (e.g., `triangular_basis @ ImmutableDenseMatrix([1/3, 2/3])`), which the class then immediately mapped back into fractional coordinates internally. This change removes that unnecessary conversion step and makes lattice initialization cleaner.

## TODOs
- [x] Update `Lattice` constructor to expect fractional coordinates
- [x] Refactor existing lattice instantiations in tests and scripts to remove Cartesian mappings
- [x] Update `basis_transform.py` logic to prevent scaling regressions
- [x] Ensure all tests pass (`pytest tests/`)

Close #79 