### PR TITLE
Add Support for `torch.BoolTensor` Style Masking in `Tensor.__getitem__`

### DIFF
--- a/src/qten/linalg/tensors.py
+++ b/src/qten/linalg/tensors.py
@@ -3573,7 +3573,9 @@ class TensorIndexing:
         entries: list[Tuple[TensorIndexType, Tuple[StateSpace, ...], TorchIndexType]],
     ) -> Tuple[StateSpace, ...]:
         tensor_positions = [
-            i for i, (idx, _, _) in enumerate(entries) if isinstance(idx, Tensor) and idx.data.dtype != torch.bool
+            i
+            for i, (idx, _, _) in enumerate(entries)
+            if isinstance(idx, Tensor) and idx.data.dtype != torch.bool
         ]
         if len(tensor_positions) == 0:
             return tuple(dim for _, dims, _ in entries for dim in dims)

--- a/src/qten/linalg/tensors.py
+++ b/src/qten/linalg/tensors.py
@@ -3402,7 +3402,9 @@ class TensorIndexing:
         self.non_none_indices = tuple(idx for idx in self.indices if idx is not None)
 
         tensor_indices = tuple(
-            cast(Tensor, idx) for idx in self.indices if isinstance(idx, Tensor)
+            cast(Tensor, idx)
+            for idx in self.indices
+            if isinstance(idx, Tensor) and idx.data.dtype != torch.bool
         )
         self.tensor_union_dims = (
             union_dims(*(idx.dims for idx in tensor_indices), allow_merge=False)
@@ -3416,7 +3418,9 @@ class TensorIndexing:
     ) -> list[TensorIndexType]:
         promoted: list[TensorIndexType] = list(indices)
         tensor_positions = [
-            i for i, idx in enumerate(indices) if isinstance(idx, Tensor)
+            i
+            for i, idx in enumerate(indices)
+            if isinstance(idx, Tensor) and idx.data.dtype != torch.bool
         ]
         if tensor_positions:
             tensor_entries = tuple(cast(Tensor, indices[i]) for i in tensor_positions)
@@ -3431,6 +3435,14 @@ class TensorIndexing:
     def _normalize(self) -> Tuple[TensorIndexType, ...]:
         return self._pad_missing_slices(self._expand_ellipsis())
 
+    @staticmethod
+    def _consumed_axes(idx: TensorIndexType) -> int:
+        if idx is None:
+            return 0
+        if isinstance(idx, Tensor) and idx.data.dtype == torch.bool:
+            return idx.rank()
+        return 1
+
     def _expand_ellipsis(self) -> Tuple[TensorIndexType, ...]:
         if not any(idx is Ellipsis for idx in self.indices):
             # No need to expand if ellipsis is not present
@@ -3444,20 +3456,19 @@ class TensorIndexing:
         left_indices = self.indices[:ellipsis_pos]
         right_indices = self.indices[ellipsis_pos + 1 :]
 
-        # None inserts output axes and does not consume source axes.
-        consumed = sum(idx is not None for idx in left_indices + right_indices)
         # Calculate how many dimensions the ellipsis should expand to
+        consumed = sum(self._consumed_axes(idx) for idx in left_indices + right_indices)
         num_full_slices = self.rank - consumed
         return left_indices + (slice(None),) * num_full_slices + right_indices
 
     def _pad_missing_slices(
         self, indices: Tuple[TensorIndexType, ...]
     ) -> Tuple[TensorIndexType, ...]:
-        non_none = sum(idx is not None for idx in indices)
-        if non_none > self.rank:
+        consumed = sum(self._consumed_axes(idx) for idx in indices)
+        if consumed > self.rank:
             raise IndexError("Too many indices for tensor")
-        if non_none < self.rank:
-            return indices + (slice(None),) * (self.rank - non_none)
+        if consumed < self.rank:
+            return indices + (slice(None),) * (self.rank - consumed)
         return indices
 
     @multimethod
@@ -3522,7 +3533,15 @@ class TensorIndexing:
         self, idx: int, v: Tensor
     ) -> Tuple[int, Tuple[StateSpace, ...], torch.Tensor]:
         if v.data.dtype == torch.bool:
-            raise NotImplementedError("Boolean Tensor indexing is not supported yet")
+            target_dims = self.dims[idx : idx + v.rank()]
+            v = v.align_all(target_dims)
+            nnz = v.data.count_nonzero().item()
+            if v.rank() == 1:
+                out_dim = v.nonzero(index_type=StateSpace)
+            else:
+                out_dim = IndexSpace.linear(int(nnz))
+            return idx + v.rank(), (out_dim,), v.data
+
         v = v.align_all(self.tensor_union_dims)
         return idx + 1, self.tensor_union_dims, v.data
 
@@ -3554,7 +3573,7 @@ class TensorIndexing:
         entries: list[Tuple[TensorIndexType, Tuple[StateSpace, ...], TorchIndexType]],
     ) -> Tuple[StateSpace, ...]:
         tensor_positions = [
-            i for i, (idx, _, _) in enumerate(entries) if isinstance(idx, Tensor)
+            i for i, (idx, _, _) in enumerate(entries) if isinstance(idx, Tensor) and idx.data.dtype != torch.bool
         ]
         if len(tensor_positions) == 0:
             return tuple(dim for _, dims, _ in entries for dim in dims)
@@ -3565,7 +3584,7 @@ class TensorIndexing:
             non_tensor_dims = tuple(
                 dim
                 for idx, dims, _ in entries
-                if not isinstance(idx, Tensor)
+                if not (isinstance(idx, Tensor) and idx.data.dtype != torch.bool)
                 for dim in dims
             )
             return self.tensor_union_dims + non_tensor_dims
@@ -3574,7 +3593,7 @@ class TensorIndexing:
         for i, (idx, dims, _) in enumerate(entries):
             if i == first_tensor_pos:
                 compiled_dims += self.tensor_union_dims
-            if isinstance(idx, Tensor):
+            if isinstance(idx, Tensor) and idx.data.dtype != torch.bool:
                 continue
             compiled_dims += dims
         return compiled_dims

--- a/src/qten/linalg/tensors.py
+++ b/src/qten/linalg/tensors.py
@@ -3572,6 +3572,39 @@ class TensorIndexing:
         self,
         entries: list[Tuple[TensorIndexType, Tuple[StateSpace, ...], TorchIndexType]],
     ) -> Tuple[StateSpace, ...]:
+        tensor_positions_all = [
+            i for i, (idx, _, _) in enumerate(entries) if isinstance(idx, Tensor)
+        ]
+        if len(tensor_positions_all) == 0:
+            return tuple(dim for _, dims, _ in entries for dim in dims)
+
+        has_bool_tensor = any(
+            isinstance(idx, Tensor) and idx.data.dtype == torch.bool
+            for idx, _, _ in entries
+        )
+        if has_bool_tensor and len(tensor_positions_all) > 1:
+            advanced_dims = self._mixed_bool_advanced_dims(entries)
+            first_tensor_pos = tensor_positions_all[0]
+            last_tensor_pos = tensor_positions_all[-1]
+
+            if last_tensor_pos - first_tensor_pos + 1 != len(tensor_positions_all):
+                non_tensor_dims = tuple(
+                    dim
+                    for idx, dims, _ in entries
+                    if not isinstance(idx, Tensor)
+                    for dim in dims
+                )
+                return advanced_dims + non_tensor_dims
+
+            compiled_dims: Tuple[StateSpace, ...] = tuple()
+            for i, (idx, dims, _) in enumerate(entries):
+                if i == first_tensor_pos:
+                    compiled_dims += advanced_dims
+                if isinstance(idx, Tensor):
+                    continue
+                compiled_dims += dims
+            return compiled_dims
+
         tensor_positions = [
             i
             for i, (idx, _, _) in enumerate(entries)
@@ -3599,6 +3632,25 @@ class TensorIndexing:
                 continue
             compiled_dims += dims
         return compiled_dims
+
+    def _mixed_bool_advanced_dims(
+        self,
+        entries: list[Tuple[TensorIndexType, Tuple[StateSpace, ...], TorchIndexType]],
+    ) -> Tuple[StateSpace, ...]:
+        shapes: list[Tuple[int, ...]] = []
+        if self.tensor_union_dims:
+            shapes.append(tuple(dim.dim for dim in self.tensor_union_dims))
+
+        for idx, _, _ in entries:
+            if not isinstance(idx, Tensor) or idx.data.dtype != torch.bool:
+                continue
+            shapes.append((int(idx.data.count_nonzero().item()),))
+
+        if not shapes:
+            return tuple()
+
+        broadcast_shape = torch.broadcast_shapes(*shapes)
+        return tuple(IndexSpace.linear(size) for size in broadcast_shape)
 
     def compile(self) -> CompiledIndices:
         """

--- a/tests/test_tensors_indexing.py
+++ b/tests/test_tensors_indexing.py
@@ -580,10 +580,10 @@ class TestTensorAdvancedGetitem:
             dims=(src,),
         )
         out = tensor[mask]
-        
+
         expected = data[mask.data]
         expected_space = src[[0, 2, 4]]
-        
+
         assert isinstance(out, Tensor)
         assert torch.equal(out.data, expected)
         assert out.dims == (expected_space,)
@@ -593,18 +593,18 @@ class TestTensorAdvancedGetitem:
         col = IndexSpace.linear(4)
         data = torch.arange(12, dtype=torch.float64).reshape(3, 4)
         tensor = Tensor(data=data, dims=(row, col))
-        
+
         mask_data = torch.zeros(3, 4, dtype=torch.bool)
         mask_data[0, 1] = True
         mask_data[1, 3] = True
         mask_data[2, 0] = True
-        
+
         mask = Tensor(data=mask_data, dims=(row, col))
         out = tensor[mask]
-        
+
         expected = data[mask_data]
         expected_space = IndexSpace.linear(3)
-        
+
         assert isinstance(out, Tensor)
         assert torch.equal(out.data, expected)
         assert out.dims == (expected_space,)
@@ -615,15 +615,15 @@ class TestTensorAdvancedGetitem:
         c = IndexSpace.linear(4)
         data = torch.arange(24, dtype=torch.float64).reshape(2, 3, 4)
         tensor = Tensor(data=data, dims=(a, b, c))
-        
+
         mask_data = torch.zeros(3, 4, dtype=torch.bool)
         mask_data[0, 1] = True
         mask_data[1, 3] = True
         mask = Tensor(data=mask_data, dims=(b, c))
-        
+
         out = tensor[:, mask]
         expected = data[:, mask_data]
-        
+
         assert isinstance(out, Tensor)
         assert torch.equal(out.data, expected)
         assert out.dims == (a, IndexSpace.linear(2))

--- a/tests/test_tensors_indexing.py
+++ b/tests/test_tensors_indexing.py
@@ -570,7 +570,7 @@ class TestTensorAdvancedGetitem:
         assert torch.equal(out.data, expected)
         assert out.dims == (a, b, c)
 
-    def test_getitem_with_tensor_advanced_bool_mask_raises_not_implemented(self):
+    def test_getitem_with_tensor_advanced_bool_mask_rank1(self):
         src = IndexSpace.linear(5)
         data = torch.arange(5, dtype=torch.float64)
         tensor = Tensor(data=data, dims=(src,))
@@ -579,10 +579,54 @@ class TestTensorAdvancedGetitem:
             data=torch.tensor([True, False, True, False, True], dtype=torch.bool),
             dims=(src,),
         )
-        with pytest.raises(
-            NotImplementedError, match="Boolean Tensor indexing is not supported yet"
-        ):
-            _ = tensor[mask]
+        out = tensor[mask]
+        
+        expected = data[mask.data]
+        expected_space = src[[0, 2, 4]]
+        
+        assert isinstance(out, Tensor)
+        assert torch.equal(out.data, expected)
+        assert out.dims == (expected_space,)
+
+    def test_getitem_with_tensor_advanced_bool_mask_higher_rank(self):
+        row = IndexSpace.linear(3)
+        col = IndexSpace.linear(4)
+        data = torch.arange(12, dtype=torch.float64).reshape(3, 4)
+        tensor = Tensor(data=data, dims=(row, col))
+        
+        mask_data = torch.zeros(3, 4, dtype=torch.bool)
+        mask_data[0, 1] = True
+        mask_data[1, 3] = True
+        mask_data[2, 0] = True
+        
+        mask = Tensor(data=mask_data, dims=(row, col))
+        out = tensor[mask]
+        
+        expected = data[mask_data]
+        expected_space = IndexSpace.linear(3)
+        
+        assert isinstance(out, Tensor)
+        assert torch.equal(out.data, expected)
+        assert out.dims == (expected_space,)
+
+    def test_getitem_with_tensor_advanced_bool_mask_with_other_slices(self):
+        a = IndexSpace.linear(2)
+        b = IndexSpace.linear(3)
+        c = IndexSpace.linear(4)
+        data = torch.arange(24, dtype=torch.float64).reshape(2, 3, 4)
+        tensor = Tensor(data=data, dims=(a, b, c))
+        
+        mask_data = torch.zeros(3, 4, dtype=torch.bool)
+        mask_data[0, 1] = True
+        mask_data[1, 3] = True
+        mask = Tensor(data=mask_data, dims=(b, c))
+        
+        out = tensor[:, mask]
+        expected = data[:, mask_data]
+        
+        assert isinstance(out, Tensor)
+        assert torch.equal(out.data, expected)
+        assert out.dims == (a, IndexSpace.linear(2))
 
     def test_getitem_with_tensor_advanced_ellipsis_at_end(self):
         a = IndexSpace.linear(2)

--- a/tests/test_tensors_indexing.py
+++ b/tests/test_tensors_indexing.py
@@ -628,6 +628,97 @@ class TestTensorAdvancedGetitem:
         assert torch.equal(out.data, expected)
         assert out.dims == (a, IndexSpace.linear(2))
 
+    def test_getitem_with_tensor_advanced_bool_mask_all_false_rank1(self):
+        src = IndexSpace.linear(5)
+        data = torch.arange(5, dtype=torch.float64)
+        tensor = Tensor(data=data, dims=(src,))
+
+        mask = Tensor(data=torch.zeros(5, dtype=torch.bool), dims=(src,))
+        out = tensor[mask]
+
+        expected = data[mask.data]
+
+        assert isinstance(out, Tensor)
+        assert torch.equal(out.data, expected)
+        assert out.dims == (IndexSpace.linear(0),)
+
+    def test_getitem_with_tensor_advanced_bool_mask_ellipsis_at_end(self):
+        a = IndexSpace.linear(2)
+        b = IndexSpace.linear(3)
+        c = IndexSpace.linear(4)
+        data = torch.arange(24, dtype=torch.float64).reshape(2, 3, 4)
+        tensor = Tensor(data=data, dims=(a, b, c))
+
+        mask_data = torch.zeros(3, 4, dtype=torch.bool)
+        mask_data[0, 1] = True
+        mask_data[1, 3] = True
+        mask_data[2, 0] = True
+        mask = Tensor(data=mask_data, dims=(b, c))
+
+        out = tensor[..., mask]
+        expected = data[..., mask_data]
+
+        assert isinstance(out, Tensor)
+        assert torch.equal(out.data, expected)
+        assert out.dims == (a, IndexSpace.linear(3))
+
+    def test_getitem_with_tensor_advanced_bool_mask_rejects_misaligned_none_prefix(
+        self,
+    ):
+        a = IndexSpace.linear(2)
+        b = IndexSpace.linear(3)
+        c = IndexSpace.linear(4)
+        data = torch.arange(24, dtype=torch.float64).reshape(2, 3, 4)
+        tensor = Tensor(data=data, dims=(a, b, c))
+
+        mask_data = torch.zeros(3, 4, dtype=torch.bool)
+        mask_data[0, 1] = True
+        mask_data[1, 3] = True
+        mask = Tensor(data=mask_data, dims=(b, c))
+
+        with pytest.raises((ValueError, IndexError)):
+            _ = tensor[None, mask]
+
+    def test_getitem_with_multiple_bool_masks_matches_torch(self):
+        row = IndexSpace.linear(3)
+        col = IndexSpace.linear(4)
+        data = torch.arange(12, dtype=torch.float64).reshape(3, 4)
+        tensor = Tensor(data=data, dims=(row, col))
+
+        row_mask = Tensor(
+            data=torch.tensor([True, False, True], dtype=torch.bool), dims=(row,)
+        )
+        col_mask = Tensor(
+            data=torch.tensor([True, False, True, False], dtype=torch.bool),
+            dims=(col,),
+        )
+
+        out = tensor[row_mask, col_mask]
+        expected = data[row_mask.data, col_mask.data]
+
+        assert isinstance(out, Tensor)
+        assert torch.equal(out.data, expected)
+        assert out.dims == (IndexSpace.linear(2),)
+
+    def test_getitem_with_bool_mask_and_integer_tensor_index_matches_torch(self):
+        row = IndexSpace.linear(3)
+        col = IndexSpace.linear(4)
+        sel = IndexSpace.linear(2)
+        data = torch.arange(12, dtype=torch.float64).reshape(3, 4)
+        tensor = Tensor(data=data, dims=(row, col))
+
+        row_mask = Tensor(
+            data=torch.tensor([True, False, True], dtype=torch.bool), dims=(row,)
+        )
+        col_idx = Tensor(data=torch.tensor([0, 2], dtype=torch.long), dims=(sel,))
+
+        out = tensor[row_mask, col_idx]
+        expected = data[row_mask.data, col_idx.data]
+
+        assert isinstance(out, Tensor)
+        assert torch.equal(out.data, expected)
+        assert out.dims == (sel,)
+
     def test_getitem_with_tensor_advanced_ellipsis_at_end(self):
         a = IndexSpace.linear(2)
         b = IndexSpace.linear(3)


### PR DESCRIPTION
### Summary
This PR introduces support for boolean tensor advanced indexing (masking) in QTen's `Tensor.__getitem__`. Previously, attempting to index a tensor with a boolean `Tensor` mask resulted in a `NotImplementedError`. This update aligns QTen's indexing behavior with native PyTorch while strictly enforcing and preserving `HilbertSpace` / `StateSpace` metadata semantics.

### Changes
- **Axis Consumption Logic**: Updated `TensorIndexing._consumed_axes` to properly recognize that an $N$-dimensional boolean mask consumes $N$ source axes, correcting the behavior of ellipsis (`...`) expansion and missing slice padding.
- **Advanced Indexing Segregation**: Modified `TensorIndexing.__init__` and `_promote_tensor_indices` to exclude boolean tensors from standard integer advanced indexing (which relies on broadcasting).
- **Metadata Alignment**: Implemented `_compile` logic for boolean tensors. The compiler now accurately extracts the target dimensions being masked and enforces metadata alignment via `mask.align_all(target_dims)`.
- **Output Subspace Generation**:
  - **Rank-1 Masks**: Leverages `nonzero(index_type=StateSpace)` to return a precise subspace of the original dimension, fully preserving `HilbertSpace` integrity.
  - **Higher-Rank Masks**: Gracefully falls back to a flattened `IndexSpace.linear(N)` (where $N$ is the number of `True` entries), mirroring `Tensor.where()` fallback semantics.
- **Dimension Placement**: Adjusted `_compose_compiled_dims` to ensure the newly generated 1D axis from a boolean mask replaces the consumed axes in-place, without the shifting behavior seen in integer advanced indexing.

### TODOs
- [x] Design pipeline for boolean masking and expected indexing rules.
- [x] Update `_expand_ellipsis` and `_pad_missing_slices` to correctly count axis consumption for boolean tensors.
- [x] Segregate boolean tensors from integer advanced indexing broadcasting.
- [x] Implement compilation logic to align mask metadata with target axes.
- [x] Generate appropriate `StateSpace` for the output dimension (subspace for rank-1, flattened `IndexSpace` for rank > 1).
- [x] Fix output dimension composition logic to place the masked axis in the correct positional order.
- [x] Add comprehensive tests for rank-1 masks, higher-rank masks, and mixed slice/mask indexing.

Close #64 