### PR TITLE
Bugfix: Unit Cell Coloring

### DIFF
--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -855,7 +855,6 @@ def plot_bandstructure_mpl(
     n_bands = eigvals_np.shape[1]
 
     # 3. Build Cartesian reciprocal coordinates once for both modes.
-    k_points = list(k_space)
     k_cart, recip, is_canonical_2d_bz, effective_dim = analyze_bandstructure_sampling(
         k_space
     )

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -251,25 +251,23 @@ def plot_structure(
                 scatter_kw["marker"]["symbol"] = "circle"
             fig.add_trace(_Scatter(**scatter_kw))
 
-    else:  # color_by == "unit_cell" — single trace to avoid O(num_cells) trace overhead
-        color_per_site = np.empty(coords.shape[0], dtype=object)
+    else:  # color_by == "unit_cell"
         for c in range(num_cells):
-            color_per_site[c * num_basis : (c + 1) * num_basis] = basis_colors[c]
-
-        scatter_kw = dict(
-            x=x,
-            y=y,
-            mode="markers",
-            marker=dict(size=marker_size, color=color_per_site.tolist()),
-            name="Sites",
-            text=hovertext,
-            hovertemplate="%{text}<extra></extra>",
-        )
-        if is_3d:
-            scatter_kw["z"] = z
-        else:
-            scatter_kw["marker"]["symbol"] = "circle"  # type: ignore[index]
-        fig.add_trace(_Scatter(**scatter_kw))
+            idx = np.arange(c * num_basis, (c + 1) * num_basis)
+            scatter_kw: dict = dict(
+                x=x[idx],
+                y=y[idx],
+                mode="markers",
+                marker=dict(size=marker_size, color=basis_colors[c]),
+                name=f"Cell {c}",
+                text=[hovertext[i] for i in idx],
+                hovertemplate="%{text}<extra></extra>",
+            )
+            if is_3d:
+                scatter_kw["z"] = z[idx]  # type: ignore[index]
+            else:
+                scatter_kw["marker"]["symbol"] = "circle"
+            fig.add_trace(_Scatter(**scatter_kw))
 
     # Spins (Optional)
     if spin_data is not None:

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -1051,7 +1051,6 @@ def plot_bandstructure(
         raise ValueError(f"nullspace_tol must be non-negative, got {nullspace_tol}")
 
     k_space = obj.dims[0]
-    k_points = list(k_space)
 
     # 2. Diagonalize
     eigvals = torch.linalg.eigvalsh(obj.data)  # (K, N_bands)


### PR DESCRIPTION
## Description
Fixed the `plot_structure` functionality so that when `color_by="unit_cell"` is used, each unit cell is now rendered as an individual trace rather than grouped into a single trace. This allows users to independently toggle or hide specific unit cells by interacting with the legend. 

## TODO
- [x] Update `plot_structure` in Plotly backend (`_plotly_impl.py`) to create separate traces for each unit cell.

Close #116 