### PR TITLE
Add additional symbolic utils for region and `HilbertSpace` operations

### DIFF
--- a/src/qten/__init__.py
+++ b/src/qten/__init__.py
@@ -43,10 +43,3 @@ from .linalg.tensors import (
 
 from .utils.devices import Device as Device
 from .utils import io as io
-from .ops import (
-    center_of_region as center_of_region,
-    get_strip_region_2d as get_strip_region_2d,
-    interstitial_centers as interstitial_centers,
-    nearest_sites as nearest_sites,
-    region_tile as region_tile,
-)

--- a/src/qten/geometries/__init__.py
+++ b/src/qten/geometries/__init__.py
@@ -17,5 +17,6 @@ from .ops import (
     get_strip_region_2d as get_strip_region_2d,
     interstitial_centers as interstitial_centers,
     nearest_sites as nearest_sites,
+    region_centering as region_centering,
     region_tile as region_tile,
 )

--- a/src/qten/geometries/ops.py
+++ b/src/qten/geometries/ops.py
@@ -433,6 +433,56 @@ def center_of_region(region: tuple[OffsetType, ...]) -> OffsetType:
     return point_type(rep=ImmutableDenseMatrix(total / len(region)), space=first.space)
 
 
+def region_centering(
+    region: tuple[OffsetType, ...], center: OffsetType
+) -> tuple[OffsetType, ...]:
+    """
+    Translate a region so that its arithmetic center lands at `center`.
+
+    Parameters
+    ----------
+    `region` : `tuple[Offset, ...] | tuple[Momentum, ...]`
+        Region to translate. All entries must share the same concrete type and
+        affine space.
+    `center` : `Offset | Momentum`
+        Target center for the translated region. It must have the same
+        concrete type and affine space as the region entries.
+
+    Returns
+    -------
+    `tuple[Offset, ...] | tuple[Momentum, ...]`
+        Region translated by `center - center_of_region(region)`. Empty input
+        returns an empty tuple.
+
+    Raises
+    ------
+    `TypeError`
+        If region entries do not all share the same concrete type and space,
+        or if `center` does not match them.
+    """
+    if len(region) == 0:
+        return ()
+
+    first = region[0]
+    point_type = type(first)
+
+    for point in region[1:]:
+        if type(point) is not point_type:
+            raise TypeError("region entries must all have the same concrete type.")
+        if point.space != first.space:
+            raise TypeError("region entries must all belong to the same space.")
+
+    if type(center) is not point_type:
+        raise TypeError(
+            "center must have the same concrete type as the region entries."
+        )
+    if center.space != first.space:
+        raise TypeError("center must belong to the same space as the region entries.")
+
+    translation = cast(OffsetType, center - center_of_region(region))
+    return tuple(cast(OffsetType, point + translation) for point in region)
+
+
 def region_tile(
     region: tuple[OffsetType, ...],
     bases: tuple[OffsetType, ...],

--- a/src/qten/ops.py
+++ b/src/qten/ops.py
@@ -7,6 +7,7 @@ from .geometries import (
     get_strip_region_2d as get_strip_region_2d,
     interstitial_centers as interstitial_centers,
     nearest_sites as nearest_sites,
+    region_centering as region_centering,
     region_tile as region_tile,
 )
 from .symbolics import (

--- a/src/qten/ops.py
+++ b/src/qten/ops.py
@@ -11,9 +11,12 @@ from .geometries import (
     region_tile as region_tile,
 )
 from .symbolics import (
+    fractional_opr as fractional_opr,
     region_hilbert as region_hilbert,
     hilbert_opr_repr as hilbert_opr_repr,
     interpolate_reciprocal_path as interpolate_reciprocal_path,
+    rebase_opr as rebase_opr,
+    translate_opr as translate_opr,
 )
 from .bands import interpolate_path as interpolate_path
 from .pointgroups.ops import (

--- a/src/qten/symbolics/__init__.py
+++ b/src/qten/symbolics/__init__.py
@@ -23,8 +23,11 @@ from .hilbert_space import (
 )
 
 from .ops import (
+    fractional_opr as fractional_opr,
     hilbert_opr_repr as hilbert_opr_repr,
     interpolate_reciprocal_path as interpolate_reciprocal_path,
     match_indices as match_indices,
+    rebase_opr as rebase_opr,
     region_hilbert as region_hilbert,
+    translate_opr as translate_opr,
 )

--- a/src/qten/symbolics/ops.py
+++ b/src/qten/symbolics/ops.py
@@ -1,17 +1,77 @@
 from collections import OrderedDict
-from typing import Callable, Dict, Optional, Sequence, TypeVar, Union, cast
+from typing import Callable, Dict, Optional, Sequence, TypeVar, Union, cast, overload
 import numpy as np
 import sympy as sy
 from sympy import ImmutableDenseMatrix
 import torch
 
-from ..geometries import Momentum, Offset, ReciprocalLattice
+from ..geometries import AffineSpace, Momentum, Offset, ReciprocalLattice
+from ..geometries.spatials import OffsetType
 from ..linalg.tensors import Tensor
-from . import HilbertSpace, Opr, StateSpace
+from . import FuncOpr, HilbertSpace, Opr, StateSpace
 from .state_space import BzPath, MomentumSpace
 from ..utils.devices import Device
 
 T = TypeVar("T")
+S = TypeVar("S", bound=AffineSpace)
+
+
+def translate_opr(d: OffsetType) -> FuncOpr[OffsetType]:
+    """
+    Build an operator that translates irreps of the same concrete type by `d`.
+
+    Parameters
+    ----------
+    `d` : `Offset | Momentum`
+        Translation to add to the targeted irrep.
+
+    Returns
+    -------
+    `FuncOpr`
+        Operator applying `x -> x + d` to irreps whose concrete type matches
+        `type(d)`.
+    """
+    point_type = cast(type[OffsetType], type(d))
+    return FuncOpr(point_type, lambda r: cast(OffsetType, r + d))
+
+
+def rebase_opr(space: S) -> FuncOpr[OffsetType]:
+    """
+    Build an operator that rebases spatial irreps into `space`.
+
+    For affine spaces this targets `Offset` irreps. For reciprocal lattices it
+    targets `Momentum` irreps.
+    """
+    point_type = cast(
+        type[OffsetType], Momentum if isinstance(space, ReciprocalLattice) else Offset
+    )
+    return FuncOpr(point_type, lambda r: cast(OffsetType, r.rebase(space)))
+
+
+@overload
+def fractional_opr() -> FuncOpr[Offset]: ...
+
+
+@overload
+def fractional_opr(T: type[OffsetType]) -> FuncOpr[OffsetType]: ...
+
+
+def fractional_opr(
+    T: type[OffsetType] | None = None,
+) -> FuncOpr[Offset] | FuncOpr[OffsetType]:
+    """
+    Build an operator that replaces a spatial irrep by its fractional form.
+
+    Parameters
+    ----------
+    `T` : `type[Offset] | type[Momentum] | None`, optional
+        Exact irrep type to target. Because `FuncOpr` matches exact runtime
+        types, reciprocal-space basis states should use
+        `fractional_opr(Momentum)`. If omitted, `Offset` is targeted.
+    """
+    if T is None:
+        return FuncOpr(Offset, Offset.fractional)
+    return FuncOpr(T, lambda r: cast(OffsetType, r.fractional()))
 
 
 def region_hilbert(bloch_space: HilbertSpace, region: Sequence[Offset]) -> HilbertSpace:

--- a/tests/test_geometry_ops.py
+++ b/tests/test_geometry_ops.py
@@ -8,6 +8,7 @@ from qten.geometries.ops import (
     get_strip_region_2d,
     interstitial_centers,
     nearest_sites,
+    region_centering,
     region_tile,
 )
 from qten.geometries.spatials import AffineSpace, Lattice, Momentum, Offset
@@ -481,6 +482,66 @@ def test_center_of_region_accounts_for_momentum_wrapping():
 def test_center_of_region_rejects_empty_region():
     with pytest.raises(ValueError, match="region must be non-empty"):
         center_of_region(())
+
+
+def test_region_centering_translates_region_to_target_offset_center():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(2),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(8, 8)),
+        unit_cell={"r": ImmutableDenseMatrix([0, 0])},
+    )
+    region = (
+        lattice.at("r", (0, 0)),
+        lattice.at("r", (2, 0)),
+        lattice.at("r", (0, 2)),
+        lattice.at("r", (2, 2)),
+    )
+
+    centered = region_centering(region, lattice.at("r", (5, 6)))
+
+    assert tuple(tuple(point.rep) for point in centered) == (
+        (4, 5),
+        (6, 5),
+        (4, 7),
+        (6, 7),
+    )
+    assert center_of_region(centered) == lattice.at("r", (5, 6))
+
+
+def test_region_centering_handles_periodic_wrapping():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(1),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    region = (
+        lattice.at("r", (0,)),
+        lattice.at("r", (1,)),
+    )
+
+    centered = region_centering(region, lattice.at("r", (0,)))
+
+    assert tuple(tuple(point.rep) for point in centered) == (
+        (sy.Rational(7, 2),),
+        (sy.Rational(1, 2),),
+    )
+    assert center_of_region(centered) == lattice.at("r", (0,))
+
+
+def test_region_centering_rejects_center_with_wrong_space():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(1),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    region = (lattice.at("r", (0,)),)
+    wrong_center = Offset(
+        rep=ImmutableDenseMatrix([0]),
+        space=AffineSpace(ImmutableDenseMatrix.eye(1)),
+    )
+
+    with pytest.raises(TypeError, match="same space as the region"):
+        region_centering(region, wrong_center)
 
 
 def test_interstitial_centers_returns_shifted_square_lattice_centers():

--- a/tests/test_hilbert.py
+++ b/tests/test_hilbert.py
@@ -4,9 +4,20 @@ from dataclasses import dataclass
 from sympy import ImmutableDenseMatrix
 
 from qten.symbolics.hilbert_space import U1Basis, U1Span, HilbertSpace
-from qten.symbolics.ops import region_hilbert
+from qten.symbolics.ops import (
+    fractional_opr,
+    rebase_opr,
+    region_hilbert,
+    translate_opr,
+)
 from qten.symbolics.state_space import MomentumSpace, brillouin_zone
-from qten.geometries.spatials import Lattice, Offset, Momentum, ReciprocalLattice
+from qten.geometries.spatials import (
+    AffineSpace,
+    Lattice,
+    Offset,
+    Momentum,
+    ReciprocalLattice,
+)
 from qten.utils.collections_ext import FrozenDict
 from qten.geometries.boundary import PeriodicBoundary
 
@@ -381,6 +392,59 @@ def test_region_hilbert_raises_for_missing_fractional_offset():
 
     with pytest.raises(ValueError, match="fractional part"):
         region_hilbert(bloch_space, [missing])
+
+
+def test_translate_opr_shifts_offset_irrep():
+    lat = _lattice(ImmutableDenseMatrix.eye(1), (5,))
+    psi = _state(Offset(rep=ImmutableDenseMatrix([1]), space=lat.affine))
+
+    translated = (
+        translate_opr(Offset(rep=ImmutableDenseMatrix([2]), space=lat.affine)) @ psi
+    )
+
+    assert translated.irrep_of(Offset) == Offset(
+        rep=ImmutableDenseMatrix([3]), space=lat.affine
+    )
+
+
+def test_rebase_opr_rebases_offset_irrep():
+    old_space = AffineSpace(ImmutableDenseMatrix([[2]]))
+    new_space = AffineSpace(ImmutableDenseMatrix([[1]]))
+    psi = _state(Offset(rep=ImmutableDenseMatrix([1]), space=old_space))
+
+    rebased = rebase_opr(new_space) @ psi
+
+    assert rebased.irrep_of(Offset) == Offset(
+        rep=ImmutableDenseMatrix([2]), space=new_space
+    )
+
+
+def test_fractional_opr_fractionalizes_offset_irrep():
+    lat = _lattice(ImmutableDenseMatrix.eye(1), (5,))
+    psi = _state(
+        Offset(rep=ImmutableDenseMatrix([sy.Rational(5, 2)]), space=lat.affine)
+    )
+
+    fractionalized = fractional_opr() @ psi
+
+    assert fractionalized.irrep_of(Offset) == Offset(
+        rep=ImmutableDenseMatrix([sy.Rational(1, 2)]), space=lat.affine
+    )
+
+
+def test_fractional_opr_fractionalizes_momentum_irrep():
+    lat = _lattice(ImmutableDenseMatrix.eye(1), (4,))
+    recip = lat.dual
+    psi = U1Basis(
+        coef=sy.Integer(1),
+        base=(Momentum(rep=ImmutableDenseMatrix([sy.Rational(5, 4)]), space=recip),),
+    )
+
+    fractionalized = fractional_opr(Momentum) @ psi
+
+    assert fractionalized.irrep_of(Momentum) == Momentum(
+        rep=ImmutableDenseMatrix([sy.Rational(1, 4)]), space=recip
+    )
 
 
 def test_hilbert_space_lookup_errors_for_no_or_multiple_matches():


### PR DESCRIPTION
## Description

This PR adds a small set of symbolic utility constructors for common spatial rewrites inside `HilbertSpace` workflows. The new APIs make it easier to express translations, rebasing, and fractional-coordinate normalization as symbolic operators, instead of building ad hoc `FuncOpr(...)` calls at each use site.

The change also expands the region utility surface with `region_centering`, which shifts a region so its arithmetic center lands on a requested target point. Together, these additions make region manipulation and symbolic spatial transformations more consistent and reusable.

## Additions

- Add `region_centering(region, center)` in `qten.geometries.ops`
  - Translates a region by `center - center_of_region(region)`
  - Preserves existing region validation rules for concrete type and space matching
  - Handles periodic wrapping through the existing spatial types

- Add symbolic operator constructors in `qten.symbolics.ops`
  - `translate_opr(d)`
  - `rebase_opr(space)`
  - `fractional_opr(...)`

- Implement the symbolic operator constructors using `FuncOpr`
  - `translate_opr(d)` targets the exact runtime irrep type of `d`
  - `rebase_opr(space)` chooses `Offset` or `Momentum` based on the target space
  - `fractional_opr()` defaults to `Offset`
  - `fractional_opr(Momentum)` supports reciprocal-space basis states explicitly

- Re-export the new symbolic utilities through:
  - `qten.symbolics`
  - `qten.ops`

- Add tests covering:
  - region centering behavior
  - periodic region centering behavior
  - invalid-center rejection
  - symbolic offset translation
  - symbolic offset rebasing
  - offset fractionalization
  - momentum fractionalization

## Notes

- `fractional_opr` remains type-explicit for `Momentum` because `FuncOpr` currently matches exact irrep runtime types rather than subclasses.
- No internal in-repo import path was found to depend on geometry helpers being exposed from the top-level `qten` namespace.
