### PR TITLE
Bugfix: Fix `Tensor.plot("bandstructure")` validation mismatch and auto surface plot delegation

### DIFF
--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -9,9 +9,7 @@ from qten.geometries.spatials import Lattice, Offset
 from qten.linalg.tensors import Tensor
 from qten.symbolics.state_space import (
     BzPath,
-    MomentumSpace,
     StateSpace,
-    same_rays,
 )
 from qten.symbolics.hilbert_space import HilbertSpace, U1Basis
 from ._utils import (
@@ -807,7 +805,8 @@ def plot_bandstructure_mpl(
 ) -> plt.Figure:
     """
     Plot the band structure of a Hamiltonian tensor using Matplotlib.
-    The tensor must have dimensions (MomentumSpace, HilbertSpace, HilbertSpace).
+    The tensor must be rank-3 with momentum samples on axis 0 and
+    matrix axes on the last two dimensions.
 
     Parameters
     ----------
@@ -828,25 +827,13 @@ def plot_bandstructure_mpl(
     """
     # 1. Check Dimensions
     if obj.rank() != 3:
-        raise ValueError(
-            f"Tensor must be rank 3 (Momentum, Hilbert, Hilbert), got rank {obj.rank()}"
-        )
+        raise ValueError(f"Tensor must be rank 3, got {obj.rank()}")
     if mode not in ("auto", "path", "surface"):
         raise ValueError(f"Invalid mode '{mode}'. Options: ('auto', 'path', 'surface')")
     if nullspace_tol < 0:
         raise ValueError(f"nullspace_tol must be non-negative, got {nullspace_tol}")
 
     k_space = obj.dims[0]
-    if not isinstance(k_space, MomentumSpace):
-        raise ValueError(f"First dimension must be MomentumSpace, got {type(k_space)}")
-
-    if not (
-        isinstance(obj.dims[1], HilbertSpace) and isinstance(obj.dims[2], HilbertSpace)
-    ):
-        raise ValueError("Last two dimensions must be HilbertSpace")
-
-    if not same_rays(obj.dims[1], obj.dims[2]):
-        raise ValueError("Last two dimensions must span the same Hilbert space")
 
     # 2. Diagonalize
     hk_data = obj.data
@@ -909,8 +896,8 @@ def plot_bandstructure_mpl(
             )
 
         ax.set_title(title)
-        ax.set_xlabel("kx (1/A)")
-        ax.set_ylabel("ky (1/A)")
+        ax.set_xlabel("kx (1/Å)")
+        ax.set_ylabel("ky (1/Å)")
         # Explicit cast to avoid type checking issues with dynamic ax
         cast(Any, ax).set_zlabel("Energy (eV)")
         if data_aspect:
@@ -962,7 +949,7 @@ def plot_bandstructure_mpl(
             ax.set_xticks(wp_x)
             ax.set_xticklabels(list(bz_path.labels))
         else:
-            ax.set_xlabel("k-path (1/A)")
+            ax.set_xlabel("k-path (1/Å)")
 
         ax.grid(True, alpha=kwargs.get("grid_alpha", 0.3))
         if kwargs.get("legend", False):

--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -842,17 +842,22 @@ def plot_bandstructure_mpl(
     n_bands = eigvals_np.shape[1]
 
     # 3. Build Cartesian reciprocal coordinates once for both modes.
-    k_cart, recip, is_canonical_2d_bz, effective_dim = analyze_bandstructure_sampling(
-        k_space
-    )
+    (
+        k_cart,
+        recip,
+        is_surface_compatible_2d_bz,
+        effective_dim,
+        surface_order,
+    ) = analyze_bandstructure_sampling(k_space)
 
     is_surface = mode == "surface" or (
-        mode == "auto" and is_canonical_2d_bz and effective_dim >= 2
+        mode == "auto" and is_surface_compatible_2d_bz and effective_dim >= 2
     )
-    if is_surface and not is_canonical_2d_bz:
+    if is_surface and not is_surface_compatible_2d_bz:
         raise ValueError(
             "Surface bandstructure plotting requires the momentum axis to be the "
-            "canonical 2D Brillouin-zone mesh returned by brillouin_zone(recip)."
+            "full 2D Brillouin-zone mesh returned by brillouin_zone(recip), up to "
+            "permutation."
         )
     if is_surface and effective_dim < 2:
         raise ValueError(
@@ -874,13 +879,20 @@ def plot_bandstructure_mpl(
                 )
 
         # Reshape eigenvalues
-        evals_grid = eigvals_np.reshape(recip.shape[0], recip.shape[1], n_bands)
+        if surface_order is None:
+            raise ValueError(
+                "Unable to map momentum samples onto the canonical BZ mesh."
+            )
+        surface_k_cart = k_cart[surface_order]
+        surface_eigvals = eigvals_np[surface_order]
+
+        evals_grid = surface_eigvals.reshape(recip.shape[0], recip.shape[1], n_bands)
         if hide_nullspace:
             evals_grid = evals_grid.copy()
             evals_grid[np.abs(evals_grid) <= nullspace_tol] = np.nan
 
-        KX = k_cart[:, 0].reshape(recip.shape[0], recip.shape[1])
-        KY = k_cart[:, 1].reshape(recip.shape[0], recip.shape[1])
+        KX = surface_k_cart[:, 0].reshape(recip.shape[0], recip.shape[1])
+        KY = surface_k_cart[:, 1].reshape(recip.shape[0], recip.shape[1])
 
         cmap = kwargs.get("cmap", "viridis")
         surface_alpha = kwargs.get("surface_alpha", 0.85)

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -1060,17 +1060,22 @@ def plot_bandstructure(
     if fig is None:
         fig = go.Figure()
 
-    k_cart, recip, is_canonical_2d_bz, effective_dim = analyze_bandstructure_sampling(
-        k_space
-    )
+    (
+        k_cart,
+        recip,
+        is_surface_compatible_2d_bz,
+        effective_dim,
+        surface_order,
+    ) = analyze_bandstructure_sampling(k_space)
 
     is_surface = mode == "surface" or (
-        mode == "auto" and is_canonical_2d_bz and effective_dim >= 2
+        mode == "auto" and is_surface_compatible_2d_bz and effective_dim >= 2
     )
-    if is_surface and not is_canonical_2d_bz:
+    if is_surface and not is_surface_compatible_2d_bz:
         raise ValueError(
             "Surface bandstructure plotting requires the momentum axis to be the "
-            "canonical 2D Brillouin-zone mesh returned by brillouin_zone(recip)."
+            "full 2D Brillouin-zone mesh returned by brillouin_zone(recip), up to "
+            "permutation."
         )
     if is_surface and effective_dim < 2:
         raise ValueError(
@@ -1081,10 +1086,16 @@ def plot_bandstructure(
     if is_surface and recip is not None:
         # === 3D Surface Plot ===
         nx, ny = recip.shape
+        if surface_order is None:
+            raise ValueError(
+                "Unable to map momentum samples onto the canonical BZ mesh."
+            )
+        surface_k_cart = k_cart[surface_order]
+        surface_eigvals = eigvals_np[surface_order]
 
-        KX = k_cart[:, 0].reshape(nx, ny)
-        KY = k_cart[:, 1].reshape(nx, ny)
-        evals_grid = eigvals_np.reshape(nx, ny, n_bands)
+        KX = surface_k_cart[:, 0].reshape(nx, ny)
+        KY = surface_k_cart[:, 1].reshape(nx, ny)
+        evals_grid = surface_eigvals.reshape(nx, ny, n_bands)
         if hide_nullspace:
             evals_grid = evals_grid.copy()
             evals_grid[np.abs(evals_grid) <= nullspace_tol] = np.nan

--- a/ext/plots/src/qten_plots/_utils.py
+++ b/ext/plots/src/qten_plots/_utils.py
@@ -6,7 +6,12 @@ from scipy.spatial import cKDTree
 
 from qten.geometries.boundary import PeriodicBoundary
 from qten.geometries.spatials import Lattice, Offset, ReciprocalLattice
-from qten.symbolics.state_space import BzPath, MomentumSpace, brillouin_zone
+from qten.symbolics.state_space import (
+    BzPath,
+    MomentumSpace,
+    brillouin_zone,
+    same_rays,
+)
 
 
 _COMMON_MARKER_ALIASES: dict[str, str] = {
@@ -185,7 +190,7 @@ def unwrap_periodic_offsets(
 
 def analyze_bandstructure_sampling(
     k_space: MomentumSpace,
-) -> tuple[np.ndarray, Optional[ReciprocalLattice], bool, int]:
+) -> tuple[np.ndarray, Optional[ReciprocalLattice], bool, int, Optional[np.ndarray]]:
     """
     Return Cartesian k-samples plus metadata needed to choose path vs surface plots.
 
@@ -195,27 +200,37 @@ def analyze_bandstructure_sampling(
     """
     k_points = list(k_space)
     if len(k_points) == 0:
-        return np.array([]), None, False, 0
+        return np.array([]), None, False, 0, None
 
     recip = k_points[0].space
     basis_mat = np.array(recip.basis.evalf()).astype(float)
     k_fracs = [np.array(k.rep).astype(float).flatten() for k in k_points]
     k_cart = np.stack(k_fracs) @ basis_mat.T
 
-    is_canonical_2d_bz = False
+    is_surface_compatible_2d_bz = False
+    surface_order = None
     if (
         isinstance(recip, ReciprocalLattice)
         and recip.dim == 2
         and all(k.space == recip for k in k_points)
     ):
         canonical_k_space = brillouin_zone(recip)
-        is_canonical_2d_bz = tuple(k_space.elements()) == tuple(
-            canonical_k_space.elements()
-        )
+        if same_rays(k_space, canonical_k_space):
+            is_surface_compatible_2d_bz = True
+            current_positions = {k: i for i, k in enumerate(k_space.elements())}
+            surface_order = np.array(
+                [current_positions[k] for k in canonical_k_space.elements()], dtype=int
+            )
 
     reciprocal_lattice = recip if isinstance(recip, ReciprocalLattice) else None
     effective_dim = _effective_dimensionality(k_cart)
-    return k_cart, reciprocal_lattice, is_canonical_2d_bz, effective_dim
+    return (
+        k_cart,
+        reciprocal_lattice,
+        is_surface_compatible_2d_bz,
+        effective_dim,
+        surface_order,
+    )
 
 
 def band_path_positions(k_space: MomentumSpace, k_cart: np.ndarray) -> np.ndarray:

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -467,7 +467,6 @@ def bandfold(
 def bandunfold(
     transform: BasisTransform,
     tensor: Tensor,
-    opt: Literal["both", "left", "right"] = "both",
 ) -> Tensor:
     """
     Unfold a folded momentum-resolved band tensor back to a primitive cell.
@@ -479,12 +478,7 @@ def bandunfold(
     primitive Brillouin zone and recovers a tensor with dimensions
     `(K_primitive, B_primitive, B_primitive)`.
 
-    As with `bandfold`, `opt` selects which Hilbert-space leg is used to infer
-    the folded supercell basis (`"left"` uses axis 1, `"right"` and `"both"`
-    use axis 2).
     """
-    if opt not in ("both", "left", "right"):
-        raise ValueError(f"Invalid option {opt} for bandunfold!")
     if tensor.rank() != 3:
         raise ValueError(
             f"Input tensor must be of rank 3, but has rank {tensor.rank()}"
@@ -537,17 +531,12 @@ def bandunfold(
     primitive_reciprocal_lattice = primitive_lattice.dual
     primitive_k_space = brillouin_zone(primitive_reciprocal_lattice)
 
-    switch_index = -2 if opt == "left" else -1
-    target_space = tensor.dims[switch_index]
-    if not isinstance(target_space, HilbertSpace):
-        raise TypeError(
-            f"Dimension at index {switch_index} must be a HilbertSpace, "
-            f"but got {type(target_space)}"
-        )
-    folded_hilbert = cast(HilbertSpace, target_space)
+    folded_hilbert = cast(HilbertSpace, tensor.dims[2])
 
     rebased_hilbert = HilbertSpace.new(
-        cast(U1Basis, psi).replace(cast(U1Basis, psi).irrep_of(Offset).rebase(primitive_lattice))
+        cast(U1Basis, psi).replace(
+            cast(U1Basis, psi).irrep_of(Offset).rebase(primitive_lattice)
+        )
         for psi in folded_hilbert
     )
 
@@ -565,7 +554,9 @@ def bandunfold(
     primitive_basis_np = np.array(
         primitive_reciprocal_lattice.basis.evalf(), dtype=precision.np_float
     )
-    folded_basis_np = np.array(folded_reciprocal_lattice.basis.evalf(), dtype=precision.np_float)
+    folded_basis_np = np.array(
+        folded_reciprocal_lattice.basis.evalf(), dtype=precision.np_float
+    )
     M_rebase = np.linalg.solve(folded_basis_np, primitive_basis_np)
     k_indices = _momentum_match_indices(
         primitive_k_space, k_space, M_rebase, device=tensor.device

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -10,10 +10,10 @@ import torch
 
 from .geometries import (
     BasisTransform,
+    InverseBasisTransform,
     Lattice,
     Momentum,
     Offset,
-    PeriodicBoundary,
     ReciprocalLattice,
 )
 from .geometries.fourier import fourier_transform
@@ -137,21 +137,38 @@ def _momentum_match_indices(
     )
     D = abs(int(round(np.linalg.det(boundary_np))))
     mapped_scaled = np.rint(mapped_wrapped * D).astype(np.int64) % D
+    dest_items = list(dest.structure.items())
+    dest_coords = np.array(
+        [
+            [int(round(float(k.rep[j, 0]) * D)) % D for j in range(dim)]
+            for k, _ in dest_items
+        ],
+        dtype=np.int64,
+    )
+    dest_indices = np.array([idx for _, idx in dest_items], dtype=np.int64)
 
-    lookup: Dict[Tuple[int, ...], int] = {}
-    for k, idx in dest.structure.items():
-        gcoord = tuple(int(round(float(k.rep[j, 0]) * D)) % D for j in range(dim))
-        lookup[gcoord] = idx
+    def _row_keys(arr: np.ndarray) -> np.ndarray:
+        arr_c = np.ascontiguousarray(arr)
+        return arr_c.view(np.dtype((np.void, arr_c.dtype.itemsize * arr_c.shape[1])))
 
-    indices: list[int] = []
-    for i in range(mapped_scaled.shape[0]):
-        gcoord = tuple(int(mapped_scaled[i, j]) for j in range(dim))
-        if gcoord not in lookup:
-            raise ValueError(
-                f"Source momentum maps to scaled coord {gcoord} (D={D}), "
-                f"not in destination BZ."
-            )
-        indices.append(lookup[gcoord])
+    src_keys = _row_keys(mapped_scaled).reshape(-1)
+    dest_keys = _row_keys(dest_coords).reshape(-1)
+    order = np.argsort(dest_keys)
+    sorted_dest_keys = dest_keys[order]
+
+    pos = np.searchsorted(sorted_dest_keys, src_keys)
+    in_range = pos < sorted_dest_keys.size
+    matched = np.zeros_like(in_range, dtype=bool)
+    matched[in_range] = sorted_dest_keys[pos[in_range]] == src_keys[in_range]
+    if not np.all(matched):
+        bad_idx = int(np.flatnonzero(~matched)[0])
+        gcoord = tuple(int(x) for x in mapped_scaled[bad_idx])
+        raise ValueError(
+            f"Source momentum maps to scaled coord {gcoord} (D={D}), "
+            f"not in destination BZ."
+        )
+
+    indices = dest_indices[order[pos]]
 
     torch_device = device.torch_device() if device is not None else None
     return Tensor(
@@ -463,22 +480,25 @@ def bandfold(
     return transformed
 
 
-# TODO: add bandunfold function
 def bandunfold(
-    transform: BasisTransform,
+    inverse_transform: InverseBasisTransform,
     tensor: Tensor,
 ) -> Tensor:
     """
-    Unfold a folded momentum-resolved band tensor back to a primitive cell.
+    Unfold a folded momentum-resolved band tensor using an inverse basis transform.
 
-    This function is the inverse-style counterpart of `bandfold` for operator
-    tensors. The input is expected to have dimensions
-    `(MomentumSpace, HilbertSpace, HilbertSpace)` where the momentum axis lives
-    on a transformed (folded) Brillouin zone. The function reconstructs the
-    primitive Brillouin zone and recovers a tensor with dimensions
-    `(K_primitive, B_primitive, B_primitive)`.
+    The input is expected to have dimensions `(MomentumSpace, HilbertSpace,
+    HilbertSpace)` where the momentum axis lives on a transformed (folded)
+    Brillouin zone. The inverse transform maps that folded lattice back to the
+    primitive one and recovers dimensions `(K_primitive, B_primitive,
+    B_primitive)`.
 
     """
+    if not isinstance(inverse_transform, InverseBasisTransform):
+        raise TypeError(
+            "bandunfold requires InverseBasisTransform, "
+            f"but got {type(inverse_transform)}"
+        )
     if tensor.rank() != 3:
         raise ValueError(
             f"Input tensor must be of rank 3, but has rank {tensor.rank()}"
@@ -514,37 +534,24 @@ def bandunfold(
     folded_reciprocal_lattice = cast(ReciprocalLattice, folded_reciprocal_lattice)
     folded_lattice = folded_reciprocal_lattice.dual
 
-    # Reconstruct the primitive lattice by inverting the basis update:
-    # folded_basis = primitive_basis @ M.
-    primitive_basis = ImmutableDenseMatrix(folded_lattice.basis @ transform.M.inv())
-    primitive_boundary_basis = transform.M @ folded_lattice.boundaries.basis
-    if any(not sy.cancel(x).is_integer for x in primitive_boundary_basis):
-        raise ValueError(
-            "Unfolded boundary basis must remain integral for PeriodicBoundary."
-        )
-    primitive_lattice = Lattice(
-        basis=primitive_basis,
-        boundaries=PeriodicBoundary(
-            ImmutableDenseMatrix(primitive_boundary_basis.applyfunc(int))
-        ),
-    )
-    primitive_reciprocal_lattice = primitive_lattice.dual
-    primitive_k_space = brillouin_zone(primitive_reciprocal_lattice)
+    primitive_lattice = cast(Lattice, inverse_transform(folded_lattice))
 
     folded_hilbert = cast(HilbertSpace, tensor.dims[2])
 
-    rebased_hilbert = HilbertSpace.new(
-        cast(U1Basis, psi).replace(
-            cast(U1Basis, psi).irrep_of(Offset).rebase(primitive_lattice)
+    primitive_reciprocal_lattice = primitive_lattice.dual
+    primitive_k_space = brillouin_zone(primitive_reciprocal_lattice)
+
+    rebased_states = []
+    for psi in folded_hilbert:
+        u1_psi = cast(U1Basis, psi)
+        rebased_states.append(
+            u1_psi.replace(u1_psi.irrep_of(Offset).rebase(primitive_lattice))
         )
-        for psi in folded_hilbert
-    )
+    rebased_hilbert = HilbertSpace.new(rebased_states)
 
     primitive_states: "OrderedDict[U1Basis, int]" = OrderedDict()
-    for psi in rebased_hilbert:
-        primitive_state = cast(U1Basis, psi).replace(
-            cast(U1Basis, psi).irrep_of(Offset).fractional()
-        )
+    for psi in rebased_states:
+        primitive_state = psi.replace(psi.irrep_of(Offset).fractional())
         if primitive_state not in primitive_states:
             primitive_states[primitive_state] = len(primitive_states)
     primitive_hilbert = HilbertSpace(structure=primitive_states)

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -8,7 +8,14 @@ from sympy import ImmutableDenseMatrix
 # TODO: Avoid using torch explicitly here.
 import torch
 
-from .geometries import BasisTransform, Momentum, Offset, ReciprocalLattice
+from .geometries import (
+    BasisTransform,
+    Lattice,
+    Momentum,
+    Offset,
+    PeriodicBoundary,
+    ReciprocalLattice,
+)
 from .geometries.fourier import fourier_transform
 from .linalg import eigh
 from .linalg.tensors import Tensor, zeros
@@ -457,6 +464,128 @@ def bandfold(
 
 
 # TODO: add bandunfold function
+def bandunfold(
+    transform: BasisTransform,
+    tensor: Tensor,
+    opt: Literal["both", "left", "right"] = "both",
+) -> Tensor:
+    """
+    Unfold a folded momentum-resolved band tensor back to a primitive cell.
+
+    This function is the inverse-style counterpart of `bandfold` for operator
+    tensors. The input is expected to have dimensions
+    `(MomentumSpace, HilbertSpace, HilbertSpace)` where the momentum axis lives
+    on a transformed (folded) Brillouin zone. The function reconstructs the
+    primitive Brillouin zone and recovers a tensor with dimensions
+    `(K_primitive, B_primitive, B_primitive)`.
+
+    As with `bandfold`, `opt` selects which Hilbert-space leg is used to infer
+    the folded supercell basis (`"left"` uses axis 1, `"right"` and `"both"`
+    use axis 2).
+    """
+    if opt not in ("both", "left", "right"):
+        raise ValueError(f"Invalid option {opt} for bandunfold!")
+    if tensor.rank() != 3:
+        raise ValueError(
+            f"Input tensor must be of rank 3, but has rank {tensor.rank()}"
+        )
+    if not isinstance(tensor.dims[0], MomentumSpace):
+        raise TypeError(
+            "The first dimension of the tensor must be a MomentumSpace, "
+            f"but is of type {type(tensor.dims[0])}"
+        )
+    if not isinstance(tensor.dims[1], HilbertSpace):
+        raise TypeError(
+            "The second dimension of the tensor must be a HilbertSpace, "
+            f"but is of type {type(tensor.dims[1])}"
+        )
+    if not isinstance(tensor.dims[2], HilbertSpace):
+        raise TypeError(
+            "The third dimension of the tensor must be a HilbertSpace, "
+            f"but is of type {type(tensor.dims[2])}"
+        )
+
+    k_space = cast(MomentumSpace, tensor.dims[0])
+    if not k_space.elements():
+        raise ValueError("MomentumSpace is empty")
+    lattice_set = set(map(lambda k: k.space, k_space))
+    if len(lattice_set) != 1:
+        raise ValueError("Invalid BZ")
+    folded_reciprocal_lattice = lattice_set.pop()
+    if not isinstance(folded_reciprocal_lattice, ReciprocalLattice):
+        raise TypeError(
+            "Space of momentum should be ReciprocalLattice, but got "
+            f"{type(folded_reciprocal_lattice)}"
+        )
+    folded_reciprocal_lattice = cast(ReciprocalLattice, folded_reciprocal_lattice)
+    folded_lattice = folded_reciprocal_lattice.dual
+
+    # Reconstruct the primitive lattice by inverting the basis update:
+    # folded_basis = primitive_basis @ M.
+    primitive_basis = ImmutableDenseMatrix(folded_lattice.basis @ transform.M.inv())
+    primitive_boundary_basis = transform.M @ folded_lattice.boundaries.basis
+    if any(not sy.cancel(x).is_integer for x in primitive_boundary_basis):
+        raise ValueError(
+            "Unfolded boundary basis must remain integral for PeriodicBoundary."
+        )
+    primitive_lattice = Lattice(
+        basis=primitive_basis,
+        boundaries=PeriodicBoundary(
+            ImmutableDenseMatrix(primitive_boundary_basis.applyfunc(int))
+        ),
+    )
+    primitive_reciprocal_lattice = primitive_lattice.dual
+    primitive_k_space = brillouin_zone(primitive_reciprocal_lattice)
+
+    switch_index = -2 if opt == "left" else -1
+    target_space = tensor.dims[switch_index]
+    if not isinstance(target_space, HilbertSpace):
+        raise TypeError(
+            f"Dimension at index {switch_index} must be a HilbertSpace, "
+            f"but got {type(target_space)}"
+        )
+    folded_hilbert = cast(HilbertSpace, target_space)
+
+    rebased_hilbert = HilbertSpace.new(
+        cast(U1Basis, psi).replace(cast(U1Basis, psi).irrep_of(Offset).rebase(primitive_lattice))
+        for psi in folded_hilbert
+    )
+
+    primitive_states: "OrderedDict[U1Basis, int]" = OrderedDict()
+    for psi in rebased_hilbert:
+        primitive_state = cast(U1Basis, psi).replace(
+            cast(U1Basis, psi).irrep_of(Offset).fractional()
+        )
+        if primitive_state not in primitive_states:
+            primitive_states[primitive_state] = len(primitive_states)
+    primitive_hilbert = HilbertSpace(structure=primitive_states)
+
+    # Route each primitive-k sector to its folded-k parent.
+    precision = get_precision_config()
+    primitive_basis_np = np.array(
+        primitive_reciprocal_lattice.basis.evalf(), dtype=precision.np_float
+    )
+    folded_basis_np = np.array(folded_reciprocal_lattice.basis.evalf(), dtype=precision.np_float)
+    M_rebase = np.linalg.solve(folded_basis_np, primitive_basis_np)
+    k_indices = _momentum_match_indices(
+        primitive_k_space, k_space, M_rebase, device=tensor.device
+    )
+
+    gathered = Tensor(
+        data=tensor.data[k_indices.data],
+        dims=(primitive_k_space, tensor.dims[1], tensor.dims[2]),
+    )
+    for dim in (1, 2):
+        if gathered.dims[dim] == folded_hilbert:
+            gathered = gathered.replace_dim(dim, rebased_hilbert)
+
+    f = fourier_transform(
+        primitive_k_space, primitive_hilbert, rebased_hilbert, device=tensor.device
+    )
+    vratio = np.sqrt(rebased_hilbert.dim / primitive_hilbert.dim)
+    f = f / vratio
+    unfolded = f @ gathered @ f.h(-2, -1)
+    return unfolded
 
 
 def bandfillings(tensor: Tensor, frac: float) -> Tensor:

--- a/src/qten/geometries/__init__.py
+++ b/src/qten/geometries/__init__.py
@@ -12,6 +12,7 @@ from .boundary import (
 )
 
 from .basis_transform import BasisTransform as BasisTransform
+from .basis_transform import InverseBasisTransform as InverseBasisTransform
 from .ops import (
     center_of_region as center_of_region,
     get_strip_region_2d as get_strip_region_2d,

--- a/src/qten/geometries/basis_transform.py
+++ b/src/qten/geometries/basis_transform.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from sympy import ImmutableDenseMatrix
 import sympy as sy
@@ -22,8 +23,24 @@ from . import (
 
 @need_validation(check_proper_transformation("M"), check_numerical("M"))
 @dataclass(frozen=True)
-class BasisTransform(Functional):
+class AbstractBasisTransform(Functional, ABC):
     M: ImmutableDenseMatrix
+
+    @abstractmethod
+    def inv(self) -> "AbstractBasisTransform":
+        pass
+
+
+class BasisTransform(AbstractBasisTransform):
+    def inv(self) -> "InverseBasisTransform":
+        """Return the inverse-view transform associated with this matrix."""
+        return InverseBasisTransform(self.M)
+
+
+class InverseBasisTransform(AbstractBasisTransform):
+    def inv(self) -> BasisTransform:
+        """Return the forward-view transform associated with this matrix."""
+        return BasisTransform(self.M)
 
 
 @lru_cache
@@ -38,6 +55,28 @@ def _supercell_shifts(
     ranges = [range(int(S[i, i])) for i in range(dim)]
     shifts = [U_inv @ ImmutableDenseMatrix(dim, 1, n) for n in product(*ranges)]
     return tuple(shifts)
+
+
+def _primitive_label_from_folded_label(label: str) -> str:
+    return label.rsplit("_", 1)[0] if "_" in label else label
+
+
+def _insert_primitive_unit_cell_site(
+    unit_cell: dict[str, ImmutableDenseMatrix],
+    label: str,
+    offset: ImmutableDenseMatrix,
+) -> None:
+    if label not in unit_cell:
+        unit_cell[label] = offset
+        return
+    if unit_cell[label] == offset:
+        return
+    suffix = 1
+    collision_label = f"{label}_{suffix}"
+    while collision_label in unit_cell:
+        suffix += 1
+        collision_label = f"{label}_{suffix}"
+    unit_cell[collision_label] = offset
 
 
 @BasisTransform.register(AffineSpace)
@@ -101,9 +140,9 @@ def lattice_transform(t: BasisTransform, lat: Lattice) -> Lattice:
     )
 
 
-@BasisTransform.register(ReciprocalLattice)
+@AbstractBasisTransform.register(ReciprocalLattice)
 def reciprocal_lattice_transform(
-    t: BasisTransform, lat: ReciprocalLattice
+    t: AbstractBasisTransform, lat: ReciprocalLattice
 ) -> ReciprocalLattice:
     """
     Generate the reciprocal lattice corresponding to the transformed direct lattice.
@@ -113,8 +152,8 @@ def reciprocal_lattice_transform(
     return transformed_dual_lat.dual
 
 
-@BasisTransform.register(Offset)
-def offset_transform(t: BasisTransform, r: Offset) -> Offset:
+@AbstractBasisTransform.register(Offset)
+def offset_transform(t: AbstractBasisTransform, r: Offset) -> Offset:
     """
 
     Transform an Offset by the basis transformation M.
@@ -123,8 +162,8 @@ def offset_transform(t: BasisTransform, r: Offset) -> Offset:
     return r.rebase(new_space)
 
 
-@BasisTransform.register(Momentum)
-def momentum_transform(t: BasisTransform, momentum: Momentum) -> Momentum:
+@AbstractBasisTransform.register(Momentum)
+def momentum_transform(t: AbstractBasisTransform, momentum: Momentum) -> Momentum:
     """
     Docstring for momentum_transform
 
@@ -133,3 +172,54 @@ def momentum_transform(t: BasisTransform, momentum: Momentum) -> Momentum:
     """
     new_space = t(momentum.space)
     return momentum.rebase(new_space)
+
+
+@InverseBasisTransform.register(AffineSpace)
+def inverse_affine_space_transform(
+    t: InverseBasisTransform, space: AffineSpace
+) -> AffineSpace:
+    """Transform an AffineSpace by the inverse basis transformation."""
+    new_basis = space.basis @ t.M.inv()
+    return AffineSpace(basis=new_basis)
+
+
+@InverseBasisTransform.register(Lattice)
+@lru_cache(maxsize=None)
+def inverse_lattice_transform(t: InverseBasisTransform, lat: Lattice) -> Lattice:
+    """
+    Invert a supercell lattice back to a primitive-cell basis defined by M.
+    """
+    if not isinstance(lat.boundaries, PeriodicBoundary):
+        raise NotImplementedError(
+            f"InverseBasisTransform currently supports PeriodicBoundary only, got {type(lat.boundaries).__name__}."
+        )
+
+    primitive_basis = lat.basis @ t.M.inv()
+    primitive_boundary_basis = t.M @ lat.boundaries.basis
+    if any(not sy.cancel(x).is_integer for x in primitive_boundary_basis):
+        raise ValueError(
+            "Inverse-transformed boundary basis must remain integral for PeriodicBoundary."
+        )
+    primitive_boundaries = PeriodicBoundary(
+        ImmutableDenseMatrix(primitive_boundary_basis.applyfunc(int))
+    )
+
+    primitive_seed = Lattice(
+        basis=ImmutableDenseMatrix(primitive_basis),
+        boundaries=primitive_boundaries,
+    )
+    primitive_unit_cell: dict[str, ImmutableDenseMatrix] = {}
+    for folded_label, folded_offset in lat.unit_cell.items():
+        primitive_offset = folded_offset.rebase(primitive_seed).fractional()
+        primitive_label = _primitive_label_from_folded_label(folded_label)
+        _insert_primitive_unit_cell_site(
+            primitive_unit_cell, primitive_label, ImmutableDenseMatrix(primitive_offset.rep)
+        )
+
+    return Lattice(
+        basis=ImmutableDenseMatrix(primitive_basis),
+        boundaries=primitive_boundaries,
+        unit_cell=FrozenDict(primitive_unit_cell),
+    )
+
+

--- a/src/qten/geometries/basis_transform.py
+++ b/src/qten/geometries/basis_transform.py
@@ -213,7 +213,9 @@ def inverse_lattice_transform(t: InverseBasisTransform, lat: Lattice) -> Lattice
         primitive_offset = folded_offset.rebase(primitive_seed).fractional()
         primitive_label = _primitive_label_from_folded_label(folded_label)
         _insert_primitive_unit_cell_site(
-            primitive_unit_cell, primitive_label, ImmutableDenseMatrix(primitive_offset.rep)
+            primitive_unit_cell,
+            primitive_label,
+            ImmutableDenseMatrix(primitive_offset.rep),
         )
 
     return Lattice(
@@ -221,5 +223,3 @@ def inverse_lattice_transform(t: InverseBasisTransform, lat: Lattice) -> Lattice
         boundaries=primitive_boundaries,
         unit_cell=FrozenDict(primitive_unit_cell),
     )
-
-

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -194,7 +194,9 @@ def test_bandunfold_preserves_primitive_unit_cell_metadata():
     tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
     transform = BasisTransform(ImmutableDenseMatrix([[2]]))
 
-    unfolded = bandunfold(InverseBasisTransform(transform.M), bandfold(transform, tensor_in))
+    unfolded = bandunfold(
+        InverseBasisTransform(transform.M), bandfold(transform, tensor_in)
+    )
     restored_lattice = unfolded.dims[1].elements()[0].irrep_of(Offset).space
 
     assert len(restored_lattice.unit_cell) == 2
@@ -243,7 +245,9 @@ def test_bandunfold_rejects_forward_basis_transform():
         unit_cell={"r": ImmutableDenseMatrix([0])},
     )
     k_space = brillouin_zone(lattice.dual)
-    h_space = HilbertSpace.new([_mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice))])
+    h_space = HilbertSpace.new(
+        [_mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice))]
+    )
     tensor_in = Tensor(
         data=torch.arange(4, dtype=torch.float64).reshape(4, 1, 1),
         dims=(k_space, h_space, h_space),

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -164,7 +164,9 @@ def test_bandunfold_handles_fractional_sector_collisions():
     assert unfolded.dims[0].dim == tensor_in.dims[0].dim
     assert unfolded.dims[1].dim == tensor_in.dims[1].dim
     assert unfolded.dims[2].dim == tensor_in.dims[2].dim
-    assert torch.allclose(unfolded.data, tensor_in.data.to(unfolded.data.dtype), atol=1e-10)
+    assert torch.allclose(
+        unfolded.data, tensor_in.data.to(unfolded.data.dtype), atol=1e-10
+    )
 
 
 def test_affine_space_transform():

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -14,7 +14,7 @@ from qten.geometries.spatials import (
 from qten.symbolics.state_space import brillouin_zone
 from qten.symbolics.hilbert_space import U1Basis, HilbertSpace
 from qten.linalg.tensors import Tensor
-from qten.geometries.basis_transform import BasisTransform
+from qten.geometries.basis_transform import BasisTransform, InverseBasisTransform
 from qten.bands import bandfold, bandunfold
 from qten.geometries.boundary import PeriodicBoundary
 
@@ -159,7 +159,7 @@ def test_bandunfold_handles_fractional_sector_collisions():
     transform = BasisTransform(ImmutableDenseMatrix([[2]]))
 
     folded = bandfold(transform, tensor_in)
-    unfolded = bandunfold(transform, folded)
+    unfolded = bandunfold(InverseBasisTransform(transform.M), folded)
 
     assert unfolded.dims[0].dim == tensor_in.dims[0].dim
     assert unfolded.dims[1].dim == tensor_in.dims[1].dim
@@ -167,6 +167,92 @@ def test_bandunfold_handles_fractional_sector_collisions():
     assert torch.allclose(
         unfolded.data, tensor_in.data.to(unfolded.data.dtype), atol=1e-10
     )
+
+
+def test_bandunfold_preserves_primitive_unit_cell_metadata():
+    basis = ImmutableDenseMatrix([[1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={
+            "a": ImmutableDenseMatrix([0]),
+            "b": ImmutableDenseMatrix([sy.Rational(1, 2)]),
+        },
+    )
+    k_space = brillouin_zone(lattice.dual)
+    h_space = HilbertSpace.new(
+        [
+            _mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice), "a"),
+            _mode(
+                Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 2)]), space=lattice),
+                "b",
+            ),
+        ]
+    )
+
+    data = torch.arange(16, dtype=torch.float64).reshape(4, 2, 2).to(torch.complex128)
+    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+    transform = BasisTransform(ImmutableDenseMatrix([[2]]))
+
+    unfolded = bandunfold(InverseBasisTransform(transform.M), bandfold(transform, tensor_in))
+    restored_lattice = unfolded.dims[1].elements()[0].irrep_of(Offset).space
+
+    assert len(restored_lattice.unit_cell) == 2
+    assert set(restored_lattice.unit_cell.keys()) == {"a", "b"}
+    restored_offsets = {site.rep for site in restored_lattice.unit_cell.values()}
+    assert ImmutableDenseMatrix([0]) in restored_offsets
+    assert ImmutableDenseMatrix([sy.Rational(1, 2)]) in restored_offsets
+
+
+def test_bandunfold_accepts_inverse_transform():
+    basis = ImmutableDenseMatrix([[1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={
+            "a": ImmutableDenseMatrix([0]),
+            "b": ImmutableDenseMatrix([sy.Rational(1, 2)]),
+        },
+    )
+    k_space = brillouin_zone(lattice.dual)
+    h_space = HilbertSpace.new(
+        [
+            _mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice), "a"),
+            _mode(
+                Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 2)]), space=lattice),
+                "b",
+            ),
+        ]
+    )
+    data = torch.arange(16, dtype=torch.float64).reshape(4, 2, 2).to(torch.complex128)
+    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+    transform = BasisTransform(ImmutableDenseMatrix([[2]]))
+
+    folded = bandfold(transform, tensor_in)
+    unfolded = bandunfold(InverseBasisTransform(transform.M), folded)
+    assert unfolded.dims[0].dim == tensor_in.dims[0].dim
+    assert unfolded.dims[1].dim == tensor_in.dims[1].dim
+    assert unfolded.dims[2].dim == tensor_in.dims[2].dim
+
+
+def test_bandunfold_rejects_forward_basis_transform():
+    basis = ImmutableDenseMatrix([[1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    h_space = HilbertSpace.new([_mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice))])
+    tensor_in = Tensor(
+        data=torch.arange(4, dtype=torch.float64).reshape(4, 1, 1),
+        dims=(k_space, h_space, h_space),
+    )
+    transform = BasisTransform(ImmutableDenseMatrix([[2]]))
+    folded = bandfold(transform, tensor_in)
+
+    with pytest.raises(TypeError, match="InverseBasisTransform"):
+        bandunfold(transform, folded)  # type: ignore[arg-type]
 
 
 def test_affine_space_transform():
@@ -183,6 +269,15 @@ def test_affine_space_transform():
 def test_basis_transform_rejects_non_invertible_matrix():
     with pytest.raises(ValueError, match="positive determinant"):
         BasisTransform(ImmutableDenseMatrix([[1, 0], [0, 0]]))
+
+
+def test_basis_transform_inv_roundtrip_type():
+    forward = BasisTransform(ImmutableDenseMatrix([[2]]))
+    inverse = forward.inv()
+    assert isinstance(inverse, InverseBasisTransform)
+    assert inverse.M == forward.M
+    assert isinstance(inverse.inv(), BasisTransform)
+    assert inverse.inv().M == forward.M
 
 
 def test_lattice_transform():
@@ -210,6 +305,30 @@ def test_lattice_transform():
     # Positions: 0 and 0.5
     assert new_lat.unit_cell["r_0"].rep == ImmutableDenseMatrix([0])
     assert new_lat.unit_cell["r_1"].rep == ImmutableDenseMatrix([sy.Rational(1, 2)])
+
+
+def test_inverse_lattice_transform_recovers_primitive_metadata():
+    basis = ImmutableDenseMatrix([[1]])
+    lat = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={
+            "a": ImmutableDenseMatrix([0]),
+            "b": ImmutableDenseMatrix([sy.Rational(1, 2)]),
+        },
+    )
+    M = ImmutableDenseMatrix([[2]])
+    forward = BasisTransform(M)
+    inverse = InverseBasisTransform(M)
+
+    restored = inverse(forward(lat))
+    assert isinstance(restored, Lattice)
+    assert restored.basis == lat.basis
+    assert restored.boundaries.basis == lat.boundaries.basis
+    assert set(restored.unit_cell.keys()) == {"a", "b"}
+    restored_offsets = {site.rep for site in restored.unit_cell.values()}
+    assert ImmutableDenseMatrix([0]) in restored_offsets
+    assert ImmutableDenseMatrix([sy.Rational(1, 2)]) in restored_offsets
 
 
 def test_reciprocal_lattice_transform():

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -15,7 +15,7 @@ from qten.symbolics.state_space import brillouin_zone
 from qten.symbolics.hilbert_space import U1Basis, HilbertSpace
 from qten.linalg.tensors import Tensor
 from qten.geometries.basis_transform import BasisTransform
-from qten.bands import bandfold
+from qten.bands import bandfold, bandunfold
 from qten.geometries.boundary import PeriodicBoundary
 
 
@@ -141,6 +141,30 @@ def test_bandfold_2d():
 
     assert torch.allclose(tensor_out.data[0].real, expected_matrix)
     assert torch.allclose(tensor_out.data[0].imag, torch.zeros_like(expected_matrix))
+
+
+def test_bandunfold_handles_fractional_sector_collisions():
+    basis = ImmutableDenseMatrix([[1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    r_offset = Offset(rep=ImmutableDenseMatrix([0]), space=lattice)
+    h_space = HilbertSpace.new([_mode(r_offset)])
+
+    data = torch.arange(4, dtype=torch.float64).reshape(4, 1, 1)
+    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+    transform = BasisTransform(ImmutableDenseMatrix([[2]]))
+
+    folded = bandfold(transform, tensor_in)
+    unfolded = bandunfold(transform, folded)
+
+    assert unfolded.dims[0].dim == tensor_in.dims[0].dim
+    assert unfolded.dims[1].dim == tensor_in.dims[1].dim
+    assert unfolded.dims[2].dim == tensor_in.dims[2].dim
+    assert torch.allclose(unfolded.data, tensor_in.data.to(unfolded.data.dtype), atol=1e-10)
 
 
 def test_affine_space_transform():

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -762,6 +762,30 @@ def test_bandstructure_plot():
     assert fig.layout.title.text == "Test Bandstructure"
 
 
+def test_bandstructure_plot_keeps_surface_mode_for_permuted_2d_k_mesh():
+    h_k = _make_square_lattice_band_tensor((4, 4))
+    k_space = h_k.dims[0]
+    permuted_k_points = list(k_space.elements())[::2] + list(k_space.elements())[1::2]
+    permuted_k_space = type(k_space)(
+        structure=OrderedDict((k, i) for i, k in enumerate(permuted_k_points))
+    )
+    permuted_h_k = Tensor(
+        data=h_k.data[[k_space.structure[k] for k in permuted_k_points]],
+        dims=(permuted_k_space, *h_k.dims[1:]),
+    )
+
+    fig = permuted_h_k.plot(
+        "bandstructure",
+        backend="plotly",
+        title="Permuted 2D Bandstructure",
+        show=False,
+    )
+
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) >= 1
+    assert all(isinstance(trace, go.Surface) for trace in fig.data)
+
+
 def test_bandstructure_plot_auto_falls_back_to_path_for_effectively_1d_k_mesh():
     h_k = _make_square_lattice_band_tensor((4, 1))
 


### PR DESCRIPTION
## Description 
- The `matplotlib` backend for `Tensor.plot("bandstructure")` has extra validation on the `dim` of the input `tensor`.
- The plotting method `Tensor.plot("bandstructure")` will delegate to line plot if the `MomentumSpace` indices are permuted out of order.