### PR TITLE
Removal of left and right opt and fixed `bandtransform`

### DIFF
--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -242,10 +242,10 @@ def bandtransform(
 
     Momentum handling:
     - The action on `Momentum` is treated as a relabeling/permutation of sectors.
-    - We align the k-axis of the transform tensors to the canonical `kspace`
-      ordering before multiplication.
-    - The input tensor itself is not pre-remapped in k; remapping is used only
-      to align transform blocks with each momentum sector.
+    - The output tensor carries the transformed momentum axis
+      `mapped_kspace = {t @ k | k in kspace}`.
+    - Each output k-block is populated from the preimage source block before
+      the Hilbert-space conjugation is applied.
 
     Notes
     -----
@@ -299,31 +299,40 @@ def bandtransform(
     kspace: MomentumSpace = cast(MomentumSpace, tensor.dims[0])
     transform_cache: Dict[HilbertSpace, Tensor] = {}
 
+    mapped_kspace = _momentum_map(kspace, lambda k: cast(Momentum, t @ k))
+
     def build_transform(space: HilbertSpace) -> Tensor:
         cached = transform_cache.get(space)
         if cached is not None:
             return cached
 
         fractional = FuncOpr(Offset, Offset.fractional)
-        new_space = cast(HilbertSpace, fractional @ t @ space)
+        raw_space = cast(HilbertSpace, t @ space)
+        new_space = cast(HilbertSpace, fractional @ raw_space)
         # The transformation will distort the unit-cell of the Hilbert space,
         # we will use fractional to return it to the original unit-cell.
         if not space.same_rays(new_space):
             raise ValueError(
                 f"Hilbert space {space} is not closed under the transform {t}!"
             )
-        bloch_transform = cast(
+        # `raw_space` keeps the transformed positions before wrapping them back
+        # into the home cell; `new_space` is the corresponding wrapped basis.
+        # Their difference is the lattice translation whose Bloch phase is
+        # encoded by the Fourier transform below.
+        transformed_fourier = fourier_transform(
+            mapped_kspace, new_space, raw_space, device=tensor.device
+        ).replace_dim(2, space)  # (K, B, B')
+        # This is the home-cell basis map analogous to the Julia
+        # `homefocktransform`: it relabels the wrapped transformed basis back
+        # onto the original Hilbert-space labels.
+        home_transform = cast(
             Tensor, space.cross_gram(new_space, device=tensor.device)
-        ).h(-2, -1)
-        f = fourier_transform(kspace, space, space, device=tensor.device)  # (K, B, B')
-        # Keep the transformed unit-cell labels explicit on the region leg so
-        # StateSpace auto-alignment does not erase the site permutation.
-        # (K, B, B) @ (B, B) @ (K, B, B)
-        transform = f @ bloch_transform @ f.h(-2, -1)  # (K, B, B)
+        ).replace_dim(1, new_space)
+        transform = home_transform @ transformed_fourier  # (K, B, B)
         transform_cache[space] = transform
         return transform
 
-    mapped_kspace = _momentum_map(kspace, lambda k: cast(Momentum, t @ k))
+    tensor = tensor.replace_dim(0, mapped_kspace)
 
     left_fourier = build_transform(cast(HilbertSpace, tensor.dims[1]))  # (K, B, B)
     left_fourier = left_fourier.replace_dim(0, mapped_kspace)  # (K, B, B)

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Callable, Dict, Literal, Optional, Sequence, Tuple, Union, cast
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import sympy as sy
@@ -227,15 +227,14 @@ def _momentum_map(
 def bandtransform(
     t: Opr,
     tensor: Tensor,
-    opt: Literal["left", "right", "both"] = "both",
 ) -> Tensor:
     """
     Apply a basis transform to a momentum-resolved operator tensor.
 
     The expected tensor shape is `(K, B_left, B_right)` where `K` is a
-    `MomentumSpace` and `B_left`, `B_right` are `HilbertSpace`s. Depending on
-    `opt`, this function applies the operator-induced basis transform on the
-    left side, right side, or both sides of the band tensor.
+    `MomentumSpace` and `B_left`, `B_right` are `HilbertSpace`s. This
+    function applies the operator-induced basis transform on both Hilbert-space
+    legs of the band tensor.
 
     For each transformed side, a k-dependent matrix is built from:
     - the action of `t` on the Hilbert-space basis (`t(space)`), and
@@ -276,9 +275,6 @@ def bandtransform(
     `tensor` : `Tensor`
         Momentum-space tensor with dims
         `(MomentumSpace, HilbertSpace, HilbertSpace)`.
-    `opt` : `Literal["left", "right", "both"]`, default `"both"`
-        Which side(s) to transform.
-
     Returns
     -------
     `Tensor`
@@ -287,12 +283,10 @@ def bandtransform(
     Raises
     ------
     `ValueError`
-        If `opt` is invalid, if `tensor` is not rank-3 with dims
-        `(MomentumSpace, HilbertSpace, HilbertSpace)`, or if a Hilbert space
-        side is not closed under the action of `t`.
+        If `tensor` is not rank-3 with dims `(MomentumSpace, HilbertSpace,
+        HilbertSpace)`, or if a Hilbert space side is not closed under the
+        action of `t`.
     """
-    if opt not in ("both", "left", "right"):
-        raise ValueError(f"Invalid option {opt} for bandtransform!")
     if not len(tensor.dims) == 3:
         raise ValueError("Input tensor must have exactly 3 dimensions.")
     if not isinstance(tensor.dims[0], MomentumSpace):
@@ -331,15 +325,13 @@ def bandtransform(
 
     mapped_kspace = _momentum_map(kspace, lambda k: cast(Momentum, t @ k))
 
-    if opt in ("both", "left"):
-        left_fourier = build_transform(cast(HilbertSpace, tensor.dims[1]))  # (K, B, B)
-        left_fourier = left_fourier.replace_dim(0, mapped_kspace)  # (K, B, B)
-        tensor = cast(Tensor, (left_fourier @ tensor))  # (K, B, B)
+    left_fourier = build_transform(cast(HilbertSpace, tensor.dims[1]))  # (K, B, B)
+    left_fourier = left_fourier.replace_dim(0, mapped_kspace)  # (K, B, B)
+    tensor = cast(Tensor, (left_fourier @ tensor))  # (K, B, B)
 
-    if opt in ("both", "right"):
-        right_fourier = build_transform(cast(HilbertSpace, tensor.dims[2]))  # (K, B, B)
-        right_fourier = right_fourier.replace_dim(0, mapped_kspace)  # (K, B, B)
-        tensor = cast(Tensor, (tensor @ right_fourier.h(-2, -1)))  # (K, B, B)
+    right_fourier = build_transform(cast(HilbertSpace, tensor.dims[2]))  # (K, B, B)
+    right_fourier = right_fourier.replace_dim(0, mapped_kspace)  # (K, B, B)
+    tensor = cast(Tensor, (tensor @ right_fourier.h(-2, -1)))  # (K, B, B)
 
     return tensor
 
@@ -347,7 +339,6 @@ def bandtransform(
 def bandfold(
     transform: BasisTransform,
     tensor: Tensor,
-    opt: Literal["both", "left", "right"] = "both",
 ) -> Tensor:
     """
     Fold a momentum-resolved band tensor into the Brillouin zone of a
@@ -361,10 +352,6 @@ def bandfold(
     change of basis is applied, and the momentum sectors are then gathered into
     the new momentum grid.
 
-    `opt` selects which Hilbert-space leg defines the enlarged basis:
-    - `"left"` uses `tensor.dims[1]`
-    - `"right"` and `"both"` use `tensor.dims[2]`
-
     Parameters
     ----------
     transform : BasisTransform
@@ -373,10 +360,6 @@ def bandfold(
     tensor : Tensor
         Rank-3 tensor with dimensions
         `(MomentumSpace, HilbertSpace, HilbertSpace)`.
-    opt : Literal["both", "left", "right"], default "both"
-        Selects which Hilbert-space leg is rebuilt in the transformed unit
-        cell. `"both"` currently follows the right-leg branch.
-
     Returns
     -------
     Tensor
@@ -428,8 +411,8 @@ def bandfold(
     # the transformed offsets on the output Hilbert-space labels.
     enlarge_unit_cell = tuple(r.rebase(lattice) for r in transformed_unit_cell)
 
-    # Transform based on opt
-    switch_index = -2 if opt == "left" else -1
+    # Follow the existing "both" branch behavior by rebuilding the right leg.
+    switch_index = -1
     target_space = tensor.dims[switch_index]
     if not isinstance(target_space, HilbertSpace):
         raise TypeError(

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -421,12 +421,10 @@ def bandfold(
     enlarge_unit_cell = tuple(r.rebase(lattice) for r in transformed_unit_cell)
 
     # Follow the existing "both" branch behavior by rebuilding the right leg.
-    switch_index = -1
-    target_space = tensor.dims[switch_index]
+    target_space = tensor.dims[-1]
     if not isinstance(target_space, HilbertSpace):
         raise TypeError(
-            f"Dimension at index {switch_index} must be a HilbertSpace, "
-            f"but got {type(target_space)}"
+            f"The last dimension must be a HilbertSpace, but got {type(target_space)}"
         )
     rebased_hilbert = HilbertSpace.new(
         cast(U1Basis, target_space.lookup({Offset: r.fractional()})).replace(r)
@@ -440,7 +438,7 @@ def bandfold(
     )
     # # Transform both sides
     f = fourier_transform(
-        k_space, tensor.dims[switch_index], rebased_hilbert, device=tensor.device
+        k_space, tensor.dims[-1], rebased_hilbert, device=tensor.device
     )
     vratio = np.sqrt(len(enlarge_unit_cell) / len(lattice.unit_cell))
     f = f / vratio

--- a/tests/test_abelian.py
+++ b/tests/test_abelian.py
@@ -891,7 +891,7 @@ def test_bandtransform_both_preserves_c4_symmetric_momentum_tensor_up_to_alignme
         basis_function_order=1,
     )
 
-    tensor_out = bandtransform(c4, tensor_in, opt="both")
+    tensor_out = bandtransform(c4, tensor_in)
     tensor_out = tensor_out.align(0, k_space).align(1, h_space).align(2, h_space)
 
     assert torch.allclose(tensor_out.data, tensor_in.data)
@@ -958,7 +958,7 @@ def test_bandtransform_both_matches_explicit_k_aligned_reference():
     )
     tensor_ref = cast(Tensor, (left_ref @ tensor_in @ right_ref.h(-2, -1)))
 
-    tensor_out = bandtransform(c4, tensor_in, opt="both")
+    tensor_out = bandtransform(c4, tensor_in)
     tensor_out = tensor_out.align(0, k_space).align(1, h_space).align(2, h_space)
     tensor_ref = tensor_ref.align(0, k_space).align(1, h_space).align(2, h_space)
 
@@ -1006,7 +1006,7 @@ def test_bandtransform_both_c4_fourfold_roundtrip_complex_tensor():
 
     out = tensor_in
     for _ in range(4):
-        out = bandtransform(c4, out, opt="both")
+        out = bandtransform(c4, out)
 
     out = out.align(0, k_space).align(1, h_space).align(2, h_space)
     assert torch.allclose(out.data, tensor_in.data)

--- a/tests/test_abelian.py
+++ b/tests/test_abelian.py
@@ -1,6 +1,8 @@
 import sympy as sy
 import torch
 import pytest
+import qten
+import qten.ops as Q
 from dataclasses import dataclass
 from sympy import ImmutableDenseMatrix
 from typing import cast
@@ -18,8 +20,11 @@ from qten.symbolics.hilbert_space import HilbertSpace, U1Basis, FuncOpr
 from qten.geometries.spatials import AffineSpace, Momentum, Offset
 from qten.geometries.spatials import Lattice
 from qten.geometries.boundary import PeriodicBoundary
+from qten.geometries.basis_transform import BasisTransform
 from qten.linalg.tensors import Tensor
 from qten.symbolics import Multiple
+from qten.phys import FFObservable
+from qten.bands import bandfillings, bandfold
 
 
 @dataclass(frozen=True)
@@ -897,6 +902,54 @@ def test_bandtransform_both_preserves_c4_symmetric_momentum_tensor_up_to_alignme
     assert torch.allclose(tensor_out.data, tensor_in.data)
 
 
+def test_bandtransform_c4_rotates_scalar_anisotropic_band_k_axis():
+    x, y = sy.symbols("x y")
+
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(2),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4, 4)),
+        unit_cell={"r": ImmutableDenseMatrix([0, 0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+
+    r0 = Offset(rep=ImmutableDenseMatrix([0, 0]), space=lattice.affine)
+    h_space = HilbertSpace.new([_state(r0, Orb("s"))])
+
+    data = torch.zeros((k_space.dim, 1, 1), dtype=torch.complex128)
+    for n, k in enumerate(k_space.elements()):
+        kx = float(k.rep[0])
+        ky = float(k.rep[1])
+        data[n, 0, 0] = complex(
+            sy.N(1.2 * sy.cos(2 * sy.pi * kx) + 0.3 * sy.cos(2 * sy.pi * ky))
+        )
+    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+
+    c4 = _affine(
+        irrep=ImmutableDenseMatrix([[0, -1], [1, 0]]),
+        axes=(x, y),
+        offset=Offset(rep=ImmutableDenseMatrix([0, 0]), space=lattice),
+        basis_function_order=1,
+    )
+
+    tensor_out = bandtransform(c4, tensor_in)
+    mapped_kspace = cast(MomentumSpace, tensor_out.dims[0])
+
+    assert mapped_kspace != k_space
+
+    source_values = {
+        k: value for k, value in zip(k_space.elements(), tensor_in.data[:, 0, 0])
+    }
+    for k, value in zip(mapped_kspace.elements(), tensor_out.data[:, 0, 0]):
+        preimage = cast(
+            Momentum,
+            _transformed(c4, _transformed(c4, _transformed(c4, k))).fractional(),
+        )
+        assert value == source_values[preimage]
+
+    aligned = tensor_out.align(0, k_space).align(1, h_space).align(2, h_space)
+    assert not torch.allclose(aligned.data, tensor_in.data)
+
+
 def test_bandtransform_both_matches_explicit_k_aligned_reference():
     x, y = sy.symbols("x y")
 
@@ -936,27 +989,33 @@ def test_bandtransform_both_matches_explicit_k_aligned_reference():
 
     def _build_transform_ref(space: HilbertSpace, kspace: MomentumSpace) -> Tensor:
         fractional = FuncOpr(Offset, Offset.fractional)
-        gspace = fractional @ (c4 @ space)
-        bloch_transform = cast(Tensor, space.cross_gram(gspace)).h(-2, -1)  # (B', B)
-        bloch_transform = bloch_transform.replace_dim(0, gspace)
-        left_fourier = fourier_transform(kspace, space, gspace)
-        right_fourier = fourier_transform(kspace, space, space)
-        return cast(Tensor, left_fourier @ bloch_transform @ right_fourier.h(-2, -1))
+        raw_space = cast(HilbertSpace, c4 @ space)
+        gspace = cast(HilbertSpace, fractional @ raw_space)
+        bloch_transform = cast(Tensor, space.cross_gram(gspace)).replace_dim(1, gspace)
+        fourier = fourier_transform(kspace, gspace, raw_space).replace_dim(2, space)
+        return cast(Tensor, bloch_transform @ fourier)
 
     mapped_kspace = k_space.map(
         lambda k: cast(Momentum, _transformed(c4, k)).fractional()
     )
-    left_ref = (
-        _build_transform_ref(h_space, k_space)
-        .replace_dim(0, mapped_kspace)
-        .align(0, k_space)
+    source_blocks = {k: tensor_in.data[i] for i, k in enumerate(k_space.elements())}
+    reordered = torch.stack(
+        [
+            source_blocks[
+                cast(
+                    Momentum,
+                    _transformed(
+                        c4, _transformed(c4, _transformed(c4, k))
+                    ).fractional(),
+                )
+            ]
+            for k in mapped_kspace.elements()
+        ]
     )
-    right_ref = (
-        _build_transform_ref(h_space, k_space)
-        .replace_dim(0, mapped_kspace)
-        .align(0, k_space)
-    )
-    tensor_ref = cast(Tensor, (left_ref @ tensor_in @ right_ref.h(-2, -1)))
+    tensor_perm = Tensor(data=reordered, dims=(mapped_kspace, h_space, h_space))
+    left_ref = _build_transform_ref(h_space, mapped_kspace)
+    right_ref = _build_transform_ref(h_space, mapped_kspace)
+    tensor_ref = cast(Tensor, (left_ref @ tensor_perm @ right_ref.h(-2, -1)))
 
     tensor_out = bandtransform(c4, tensor_in)
     tensor_out = tensor_out.align(0, k_space).align(1, h_space).align(2, h_space)
@@ -1010,6 +1069,118 @@ def test_bandtransform_both_c4_fourfold_roundtrip_complex_tensor():
 
     out = out.align(0, k_space).align(1, h_space).align(2, h_space)
     assert torch.allclose(out.data, tensor_in.data)
+
+
+def test_bandtransform_c4_twice_restores_c2_symmetric_but_not_c4_tensor():
+    x, y = sy.symbols("x y")
+
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(2),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4, 4)),
+        unit_cell={"r": ImmutableDenseMatrix([0, 0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+
+    r0 = Offset(rep=ImmutableDenseMatrix([0, 0]), space=lattice.affine)
+    h_space = HilbertSpace.new([_state(r0, Orb("s"))])
+
+    c4 = _affine(
+        irrep=ImmutableDenseMatrix([[0, -1], [1, 0]]),
+        axes=(x, y),
+        offset=Offset(rep=ImmutableDenseMatrix([0, 0]), space=lattice),
+        basis_function_order=1,
+    )
+
+    seed_data = torch.zeros((k_space.dim, 1, 1), dtype=torch.complex128)
+    for n, k in enumerate(k_space.elements()):
+        kx = float(k.rep[0])
+        ky = float(k.rep[1])
+        seed_data[n, 0, 0] = complex(
+            sy.N(1.2 * sy.cos(2 * sy.pi * kx) + 0.3 * sy.cos(2 * sy.pi * ky))
+        )
+    seed = Tensor(data=seed_data, dims=(k_space, h_space, h_space))
+
+    c2_part = bandtransform(c4, bandtransform(c4, seed)).align_all(seed.dims)
+    tensor_in = (seed + c2_part).align_all(seed.dims)
+
+    once = bandtransform(c4, tensor_in).align_all(seed.dims)
+    twice = bandtransform(c4, once).align_all(seed.dims)
+
+    assert not torch.allclose(once.data, tensor_in.data)
+    assert torch.allclose(twice.data, tensor_in.data)
+
+
+def test_bandtransform_notebook_cb_c4_symmetry_reproducer():
+    square = Lattice(
+        basis=sy.ImmutableMatrix([[1, 0], [0, 1]]),
+        unit_cell={"r": sy.ImmutableMatrix([0, 0])},
+        shape=(64, 64),
+    )
+
+    c4 = pointgroup("c4-xy:xy")
+
+    a1, a2 = square.basis_vectors()
+    R_a1 = FuncOpr(Offset, lambda r: r + a1)
+    R_a2 = FuncOpr(Offset, lambda r: r + a2)
+
+    psi_r = U1Basis.new(square.at("r"), c4.basis_table[1])
+    t = sy.Number(1)
+
+    tb = FFObservable()
+    tb.add_bond(-t, psi_r, R_a2 @ psi_r)
+    tb.add_bond(-t, psi_r, R_a1 @ psi_r)
+    harmonic = tb.to_tensor()
+
+    bloch_space = HilbertSpace.new([psi_r])
+    k_space = brillouin_zone(square.dual)
+    F = Q.fourier_transform(k_space, bloch_space, harmonic.dims[0])
+    bloch = F @ harmonic @ F.h(-2, -1)
+    gs = bandfillings(bloch, 0.5)
+    C_gs = qten.eye(bloch.dims) - gs @ gs.h(-2, -1)
+
+    blocking = BasisTransform(sy.ImmutableMatrix([[4, 0], [0, 4]]))
+    C_b = bandfold(blocking, C_gs)
+
+    C_rot = bandtransform(AbelianOpr(c4), C_b).align_all(C_b.dims)
+    assert C_b.allclose(C_rot)
+
+
+def test_bandtransform_notebook_cb_c4_symmetry_about_block_center():
+    square = Lattice(
+        basis=sy.ImmutableMatrix([[1, 0], [0, 1]]),
+        unit_cell={"r": sy.ImmutableMatrix([0, 0])},
+        shape=(64, 64),
+    )
+
+    c4 = pointgroup("c4-xy:xy")
+
+    a1, a2 = square.basis_vectors()
+    R_a1 = FuncOpr(Offset, lambda r: r + a1)
+    R_a2 = FuncOpr(Offset, lambda r: r + a2)
+
+    psi_r = U1Basis.new(square.at("r"), c4.basis_table[1])
+    t = sy.Number(1)
+
+    tb = FFObservable()
+    tb.add_bond(-t, psi_r, R_a2 @ psi_r)
+    tb.add_bond(-t, psi_r, R_a1 @ psi_r)
+    harmonic = tb.to_tensor()
+
+    bloch_space = HilbertSpace.new([psi_r])
+    k_space = brillouin_zone(square.dual)
+    F = Q.fourier_transform(k_space, bloch_space, harmonic.dims[0])
+    bloch = F @ harmonic @ F.h(-2, -1)
+    gs = bandfillings(bloch, 0.5)
+    C_gs = qten.eye(bloch.dims) - gs @ gs.h(-2, -1)
+
+    blocking = BasisTransform(sy.ImmutableMatrix([[4, 0], [0, 4]]))
+    C_b = bandfold(blocking, C_gs)
+
+    cent = Q.center_of_region(C_b.dims[1].irrep_of(Offset))
+    centered_c4 = AbelianOpr(c4).fixpoint_at(cent)
+    C_rot = bandtransform(centered_c4, C_b).align_all(C_b.dims)
+
+    assert C_b.allclose(C_rot)
 
 
 def test_affine_query_c3_xy_and_inverse_orientation():

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -305,7 +305,7 @@ def test_bandfold_device(device):
     T = BasisTransform(M=ImmutableDenseMatrix([[2]]))
 
     # Run bandfold, it should operate completely on device
-    H_folded = bandfold(T, H, opt="both")
+    H_folded = bandfold(T, H)
 
     # Assert output device matches input device
     assert H_folded.device == device


### PR DESCRIPTION
See #117.

## Summary
- Removed the `left` / `right` option from `bandfold` and `bandtransform`
- Simplified both APIs so the transformation is always applied consistently on both Hilbert-space legs
- Fixed a momentum-space bug in `bandtransform`

## What Was Wrong In `bandtransform`
`bandtransform` was previously inconsistent about which momentum axis the Bloch-phase part of the transform was evaluated on.

For a symmetry operation `g`, the transformed band tensor should satisfy
```math
H'(k') = U(k')\, H(g^{-1}k')\, U(k')^\dagger,
\qquad k' = gk
```

The bug was that the Hilbert-space transform matrix was still being built using the original `kspace`, even after the band tensor itself had already been relabeled onto the transformed momentum axis `mapped_kspace`.

That meant the Fourier phase coming from wrapping transformed real-space points back into the home cell was attached to the wrong momentum label. In practice this caused incorrect behavior for blocked `(K, B, B)` tensors:
- origin-centered symmetry checks could fail even when the transformed tensor should agree,
- `bandtransform` could preserve the right qualitative permutation of momentum sectors but attach phases using the wrong `k`,
- blocked bands could fail to transform correctly under point-group operations.

## Fix
The fix is to build the Fourier phase factor in `bandtransform` on `mapped_kspace` instead of the original `kspace`.

Conceptually:
- `raw_space = g @ space` keeps the transformed positions before wrapping,
- `new_space = fractional(raw_space)` gives the wrapped basis positions in the home cell,
- the Fourier transform between `new_space` and `raw_space` encodes the lattice-translation phase from that wrapping,
- that Fourier transform must be evaluated on the transformed momentum axis `mapped_kspace`, because the tensor has already been relabeled to `k' = gk`.

So the corrected transform now uses the transformed momentum label consistently through the whole one-leg Bloch transform.

## User-Visible Effect
This fixes the blocked-band symmetry behavior:
- both the origin-centered and centered `C4` notebook-derived cases now pass,
- anisotropic bands are rotated correctly under one symmetry application,
- applying `bandtransform(g, ...)` repeatedly returns the original tensor after `order(g)` applications.

## API Cleanup
The `left` / `right` option on `bandfold` and `bandtransform` was removed.

Reason:
- for band tensors with shape `(K, B, B)`, one-sided application is not a well-defined symmetry action in the intended sense,
- the physically meaningful operation is the two-sided transform
  ```math
  H \mapsto U H U^\dagger
  ```
- removing the option avoids ambiguous semantics and makes the API match the actual mathematical operation.

## Tests
Added / updated coverage for:
- non-symmetric anisotropic bands rotating correctly under `C4`,
- repeated application of `bandtransform` returning to the original tensor after the symmetry order,
- blocked notebook-derived `C4` symmetry cases for both origin-centered and block-centered transforms.