### PR TITLE
Add `nearest_bands` function to select bands near a specified eigenvalue at a given k-point

### DIFF
--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -782,3 +782,105 @@ def bandselect(
         selected[name] = pack(mask)
 
     return selected
+
+
+def nearest_bands(
+    h_k: Tensor,
+    point: Union[str, Sequence[float]] = "Gamma",
+    close_to: float = 0.0,
+    tol: float = 1e-6,
+    points: Optional[Dict[str, Sequence[float]]] = None,
+) -> Tensor:
+    r"""
+    Select bands near ``close_to`` at a single anchor k-point, then project
+    ``H(k)`` onto that subspace for every momentum.
+
+    The anchor momentum is located by:
+    - a string label looked up in ``points`` (``"Gamma"`` defaults to the
+      origin when the label is absent from ``points``), or
+    - an explicit fractional-coordinate tuple.
+
+    ``h_k`` is diagonalized at the anchor k-point, and the eigenvectors whose
+    eigenvalues lie within ``tol`` of ``close_to`` are collected into a
+    rectangular matrix ``V`` of shape ``(N, H)``. The returned tensor is
+    :math:`V^{\dagger} H(k) V` for every ``k``.
+
+    Parameters
+    ----------
+    `h_k` : `Tensor`
+        Hamiltonian tensor with dims `(MomentumSpace, HilbertSpace, HilbertSpace)`.
+    `point` : `str` or fractional coordinate, default `"Gamma"`
+        Anchor k-point. When a string, it is looked up in `points`.
+    `close_to` : `float`, default `0.0`
+        Target eigenvalue for the subspace selection.
+    `tol` : `float`, default `1e-6`
+        Half-window around `close_to` for including eigenvectors.
+    `points` : dict, optional
+        Mapping from labels to fractional coordinates.
+
+    Returns
+    -------
+    `Tensor`
+        Tensor with dims `(MomentumSpace, IndexSpace, IndexSpace)` whose last
+        two axes span the selected subspace.
+    """
+    if h_k.rank() != 3:
+        raise ValueError(f"Input tensor must be of rank 3, but has rank {h_k.rank()}")
+    if not isinstance(h_k.dims[0], MomentumSpace):
+        raise TypeError("The first dimension of the tensor must be a MomentumSpace.")
+    if not isinstance(h_k.dims[1], HilbertSpace):
+        raise TypeError("The second dimension of the tensor must be a HilbertSpace.")
+    if not isinstance(h_k.dims[2], HilbertSpace):
+        raise TypeError("The third dimension of the tensor must be a HilbertSpace.")
+
+    kspace = cast(MomentumSpace, h_k.dims[0])
+    k_items = list(kspace.structure.items())
+    if not k_items:
+        raise ValueError("MomentumSpace is empty")
+
+    dim = k_items[0][0].space.dim
+    if isinstance(point, str):
+        if points is not None and point in points:
+            target_frac = tuple(float(x) for x in points[point])
+        elif point == "Gamma":
+            target_frac = tuple(0.0 for _ in range(dim))
+        else:
+            raise KeyError(
+                f"Point {point!r} not found in `points`; "
+                "provide a `points` mapping or pass explicit fractional coordinates."
+            )
+    else:
+        target_frac = tuple(float(x) for x in point)
+    if len(target_frac) != dim:
+        raise ValueError(
+            f"Anchor point has {len(target_frac)} coordinates but momentum "
+            f"space has dimension {dim}."
+        )
+
+    precision = get_precision_config()
+    k_frac = np.array(
+        [[float(k.rep[j, 0]) for j in range(dim)] for k, _ in k_items],
+        dtype=precision.np_float,
+    )
+    k_indices = np.array([idx for _, idx in k_items], dtype=np.int64)
+    target_arr = np.asarray(target_frac, dtype=precision.np_float)
+    diff = k_frac - target_arr
+    diff = diff - np.round(diff)
+    dist = np.linalg.norm(diff, axis=1)
+    best_row = int(np.argmin(dist))
+    anchor_idx = int(k_indices[best_row])
+
+    H_anchor = h_k.data[anchor_idx]
+    eigenvalues, eigenvectors = torch.linalg.eigh(H_anchor)
+
+    mask = (eigenvalues - close_to).abs() <= tol
+    selected = torch.nonzero(mask, as_tuple=False).flatten()
+    n_selected = int(selected.numel())
+
+    V = eigenvectors.index_select(-1, selected)  # (N, H)
+    V_dag = V.conj().transpose(-2, -1)  # (H, N)
+
+    projected = torch.einsum("ia,kab,bj->kij", V_dag, h_k.data, V)
+
+    out_space = IndexSpace.linear(n_selected)
+    return Tensor(data=projected, dims=(kspace, out_space, out_space))

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -792,37 +792,82 @@ def nearest_bands(
     points: Optional[Dict[str, Sequence[float]]] = None,
 ) -> Tensor:
     r"""
-    Select bands near ``close_to`` at a single anchor k-point, then project
-    ``H(k)`` onto that subspace for every momentum.
+    Project a momentum-resolved Hamiltonian onto bands selected at one k-point.
 
-    The anchor momentum is located by:
-    - a string label looked up in ``points`` (``"Gamma"`` defaults to the
-      origin when the label is absent from ``points``), or
-    - an explicit fractional-coordinate tuple.
+    The input `h_k` is diagonalized at a single anchor momentum \(k_0\).
+    Eigenvectors whose anchor eigenvalues lie within `tol` of `close_to` are
+    collected into a rectangular matrix \(V\). If the input Hilbert dimension is
+    \(N\) and \(S\) bands are selected, then `V` has shape `(N, S)` and the
+    returned tensor stores \(V^\dagger H(k) V\) for every momentum \(k\).
 
-    ``h_k`` is diagonalized at the anchor k-point, and the eigenvectors whose
-    eigenvalues lie within ``tol`` of ``close_to`` are collected into a
-    rectangular matrix ``V`` of shape ``(N, H)``. The returned tensor is
-    :math:`V^{\dagger} H(k) V` for every ``k``.
+    Projection convention
+    ---------------------
+    At the selected anchor sector, the code computes
+    `eigenvalues, eigenvectors = torch.linalg.eigh(H_anchor)`. The columns of
+    `eigenvectors` with \(|\epsilon_n(k_0) - \mathrm{close\_to}| \le \mathrm{tol}\)
+    form \(V\). The projected block at each momentum is
+    \(H_{\mathrm{proj}}(k) = V^\dagger H(k) V\).
+
+    In implementation terms, this projection is the einsum
+    `torch.einsum("ia,kab,bj->kij", V_dag, h_k.data, V)`.
+
+    Anchor selection
+    ----------------
+    - A string `point` is looked up in `points`.
+    - `"Gamma"` defaults to the fractional origin when absent from `points`.
+    - A coordinate sequence is interpreted directly as fractional coordinates.
+    - Fractional-coordinate differences are wrapped by subtracting the nearest
+      integer, so equivalent periodic coordinates select the same anchor.
+
+    If no eigenvalue falls inside the tolerance window, the result has two
+    zero-dimensional [`IndexSpace`][qten.symbolics.state_space.IndexSpace] axes
+    and data shape `(len(kspace), 0, 0)`.
+
+    Notes
+    -----
+    The selected subspace is fixed by the anchor momentum only. The same
+    anchor eigenvector matrix \(V\) is applied to every \(H(k)\); this is a
+    projection onto an anchor-defined subspace, not a separately diagonalized
+    band selection at each momentum.
 
     Parameters
     ----------
-    `h_k` : `Tensor`
-        Hamiltonian tensor with dims `(MomentumSpace, HilbertSpace, HilbertSpace)`.
-    `point` : `str` or fractional coordinate, default `"Gamma"`
-        Anchor k-point. When a string, it is looked up in `points`.
-    `close_to` : `float`, default `0.0`
+    h_k : Tensor
+        Hamiltonian tensor with dims
+        ([`MomentumSpace`][qten.symbolics.state_space.MomentumSpace],
+        [`HilbertSpace`][qten.symbolics.hilbert_space.HilbertSpace],
+        [`HilbertSpace`][qten.symbolics.hilbert_space.HilbertSpace]).
+    point : str or Sequence[float], default="Gamma"
+        Anchor k-point. String labels are resolved through `points`, except
+        `"Gamma"` which defaults to the fractional origin.
+    close_to : float, default=0.0
         Target eigenvalue for the subspace selection.
-    `tol` : `float`, default `1e-6`
-        Half-window around `close_to` for including eigenvectors.
-    `points` : dict, optional
+    tol : float, default=1e-6
+        Half-width of the eigenvalue window around `close_to`.
+    points : dict[str, Sequence[float]], optional
         Mapping from labels to fractional coordinates.
 
     Returns
     -------
-    `Tensor`
-        Tensor with dims `(MomentumSpace, IndexSpace, IndexSpace)` whose last
-        two axes span the selected subspace.
+    Tensor
+        Projected Hamiltonian with dims
+        ([`MomentumSpace`][qten.symbolics.state_space.MomentumSpace],
+        [`IndexSpace`][qten.symbolics.state_space.IndexSpace],
+        [`IndexSpace`][qten.symbolics.state_space.IndexSpace]). The last two
+        axes span the selected subspace.
+
+    Raises
+    ------
+    ValueError
+        If `h_k` is not rank 3, if the momentum space is empty, or if the
+        anchor coordinate dimension does not match the momentum-space
+        dimension.
+    TypeError
+        If the input dimensions are not
+        `(MomentumSpace, HilbertSpace, HilbertSpace)`.
+    KeyError
+        If `point` is a string other than `"Gamma"` and is not present in
+        `points`.
     """
     if h_k.rank() != 3:
         raise ValueError(f"Input tensor must be of rank 3, but has rank {h_k.rank()}")

--- a/tests/test_bands.py
+++ b/tests/test_bands.py
@@ -4,7 +4,11 @@ import torch
 import sympy as sy
 from sympy import ImmutableDenseMatrix
 
-from qten.bands import bandselect, interpolate_path
+from qten.bands import (
+    nearest_bands,
+    bandselect,
+    interpolate_path,
+)
 from qten.geometries.boundary import PeriodicBoundary
 from qten.geometries.spatials import Lattice
 from qten.linalg.tensors import Tensor
@@ -275,3 +279,155 @@ def test_interpolate_reciprocal_path_accessible_via_geometries():
     recip = _recip_2d()
     path = interpolate_reciprocal_path(recip, [(0, 0), (0.5, 0)], n_points=10)
     assert isinstance(path, BzPath)
+
+
+# --- bands_near_value_as_tensor_KHH tests ---
+
+
+def _nondiag_band_tensor() -> Tensor:
+    """Build a (2, 2, 2) Hamiltonian with non-diagonal anchor eigenbasis.
+
+    H(k=Gamma) = [[0, 1], [1, 0]] has eigvecs (1,-1)/sqrt(2) (eigval -1)
+    and (1, 1)/sqrt(2) (eigval +1).
+    H(k=X)     = [[1, 2], [2, 3]] is used to exercise the projection math.
+    """
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix([[1]]),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(2)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    band_space = _space("band", 2)
+
+    h_gamma = torch.tensor([[0.0, 1.0], [1.0, 0.0]], dtype=torch.complex128)
+    h_x = torch.tensor([[1.0, 2.0], [2.0, 3.0]], dtype=torch.complex128)
+    data = torch.stack([h_gamma, h_x], dim=0)
+    return Tensor(data=data, dims=(k_space, band_space, band_space))
+
+
+def test_bands_near_value_selects_single_band_at_gamma():
+    tensor, _ = _band_tensor()
+
+    result = nearest_bands(
+        tensor, point="Gamma", close_to=-1.0, tol=1e-6
+    )
+
+    assert result.dims[0] == tensor.dims[0]
+    assert isinstance(result.dims[1], IndexSpace)
+    assert isinstance(result.dims[2], IndexSpace)
+    assert result.dims[1].dim == 1
+    assert result.dims[2].dim == 1
+    # Diagonal H: eigenvector for eigenvalue -1 at Gamma is e_1, so the
+    # projection just picks the (1, 1) diagonal entry at every k.
+    expected = torch.tensor([[[-1.0]], [[1.0]]], dtype=torch.complex128)
+    assert torch.allclose(result.data, expected)
+
+
+def test_bands_near_value_selects_multiple_bands_in_tolerance_window():
+    tensor, _ = _band_tensor()
+
+    result = nearest_bands(
+        tensor, point="Gamma", close_to=0.5, tol=1.6
+    )
+
+    assert result.dims[1].dim == 2
+    assert result.dims[2].dim == 2
+    expected = torch.zeros((2, 2, 2), dtype=torch.complex128)
+    expected[0] = torch.diag(torch.tensor([-1.0, 2.0], dtype=torch.complex128))
+    expected[1] = torch.diag(torch.tensor([1.0, 3.0], dtype=torch.complex128))
+    assert torch.allclose(result.data, expected)
+
+
+def test_bands_near_value_with_points_dict_non_gamma():
+    tensor, _ = _band_tensor()
+
+    result = nearest_bands(
+        tensor,
+        point="X",
+        close_to=1.0,
+        tol=1e-6,
+        points={"X": (0.5,)},
+    )
+
+    assert result.dims[1].dim == 1
+    # At X the eigenvalue 1.0 belongs to band 1; the projection picks (1, 1).
+    expected = torch.tensor([[[-1.0]], [[1.0]]], dtype=torch.complex128)
+    assert torch.allclose(result.data, expected)
+
+
+def test_bands_near_value_with_explicit_fractional_tuple():
+    tensor, _ = _band_tensor()
+
+    result = nearest_bands(
+        tensor, point=(0.5,), close_to=3.0, tol=1e-6
+    )
+
+    assert result.dims[1].dim == 1
+    # Band 2 (eigvalue 3 at X) projects to (2, 2) diagonal entries.
+    expected = torch.tensor([[[2.0]], [[3.0]]], dtype=torch.complex128)
+    assert torch.allclose(result.data, expected)
+
+
+def test_bands_near_value_empty_subspace_when_no_match():
+    tensor, _ = _band_tensor()
+
+    result = nearest_bands(tensor, close_to=1000.0, tol=1e-6)
+
+    assert result.dims[1].dim == 0
+    assert result.dims[2].dim == 0
+    assert result.data.shape == (2, 0, 0)
+
+
+def test_bands_near_value_non_diagonal_projection_math():
+    tensor = _nondiag_band_tensor()
+
+    result = nearest_bands(
+        tensor, point="Gamma", close_to=-1.0, tol=1e-6
+    )
+
+    # Selected eigenvector at Gamma is v = (1, -1)/sqrt(2).
+    # v^H H(Gamma) v = -1, v^H H(X) v = 0.5*(1 - 2 - 2 + 3) = 0.
+    assert result.dims[1].dim == 1
+    expected = torch.tensor([[[-1.0]], [[0.0]]], dtype=torch.complex128)
+    assert torch.allclose(result.data, expected, atol=1e-10)
+
+
+def test_bands_near_value_wraps_fractional_coordinates():
+    tensor, _ = _band_tensor()
+
+    result = nearest_bands(
+        tensor, point=(1.0,), close_to=-1.0, tol=1e-6
+    )
+
+    # (1.0,) wraps to Gamma = (0,), so this matches the Gamma selection.
+    expected = torch.tensor([[[-1.0]], [[1.0]]], dtype=torch.complex128)
+    assert torch.allclose(result.data, expected)
+
+
+def test_bands_near_value_unknown_label_without_points_raises():
+    tensor, _ = _band_tensor()
+
+    with pytest.raises(KeyError, match="not found"):
+        nearest_bands(tensor, point="Z")
+
+
+def test_bands_near_value_dimension_mismatch_raises():
+    tensor, _ = _band_tensor()
+
+    with pytest.raises(ValueError, match="coordinates"):
+        nearest_bands(tensor, point=(0.0, 0.0))
+
+
+def test_bands_near_value_rejects_wrong_rank():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix([[1]]),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(2)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    band_space = _space("band", 2)
+    data = torch.zeros((2, 2), dtype=torch.complex128)
+    rank2 = Tensor(data=data, dims=(k_space, band_space))
+
+    with pytest.raises(ValueError, match="rank 3"):
+        nearest_bands(rank2)

--- a/tests/test_bands.py
+++ b/tests/test_bands.py
@@ -308,9 +308,7 @@ def _nondiag_band_tensor() -> Tensor:
 def test_bands_near_value_selects_single_band_at_gamma():
     tensor, _ = _band_tensor()
 
-    result = nearest_bands(
-        tensor, point="Gamma", close_to=-1.0, tol=1e-6
-    )
+    result = nearest_bands(tensor, point="Gamma", close_to=-1.0, tol=1e-6)
 
     assert result.dims[0] == tensor.dims[0]
     assert isinstance(result.dims[1], IndexSpace)
@@ -326,9 +324,7 @@ def test_bands_near_value_selects_single_band_at_gamma():
 def test_bands_near_value_selects_multiple_bands_in_tolerance_window():
     tensor, _ = _band_tensor()
 
-    result = nearest_bands(
-        tensor, point="Gamma", close_to=0.5, tol=1.6
-    )
+    result = nearest_bands(tensor, point="Gamma", close_to=0.5, tol=1.6)
 
     assert result.dims[1].dim == 2
     assert result.dims[2].dim == 2
@@ -358,9 +354,7 @@ def test_bands_near_value_with_points_dict_non_gamma():
 def test_bands_near_value_with_explicit_fractional_tuple():
     tensor, _ = _band_tensor()
 
-    result = nearest_bands(
-        tensor, point=(0.5,), close_to=3.0, tol=1e-6
-    )
+    result = nearest_bands(tensor, point=(0.5,), close_to=3.0, tol=1e-6)
 
     assert result.dims[1].dim == 1
     # Band 2 (eigvalue 3 at X) projects to (2, 2) diagonal entries.
@@ -381,9 +375,7 @@ def test_bands_near_value_empty_subspace_when_no_match():
 def test_bands_near_value_non_diagonal_projection_math():
     tensor = _nondiag_band_tensor()
 
-    result = nearest_bands(
-        tensor, point="Gamma", close_to=-1.0, tol=1e-6
-    )
+    result = nearest_bands(tensor, point="Gamma", close_to=-1.0, tol=1e-6)
 
     # Selected eigenvector at Gamma is v = (1, -1)/sqrt(2).
     # v^H H(Gamma) v = -1, v^H H(X) v = 0.5*(1 - 2 - 2 + 3) = 0.
@@ -395,9 +387,7 @@ def test_bands_near_value_non_diagonal_projection_math():
 def test_bands_near_value_wraps_fractional_coordinates():
     tensor, _ = _band_tensor()
 
-    result = nearest_bands(
-        tensor, point=(1.0,), close_to=-1.0, tol=1e-6
-    )
+    result = nearest_bands(tensor, point=(1.0,), close_to=-1.0, tol=1e-6)
 
     # (1.0,) wraps to Gamma = (0,), so this matches the Gamma selection.
     expected = torch.tensor([[[-1.0]], [[1.0]]], dtype=torch.complex128)


### PR DESCRIPTION
- [x] Introduced the `nearest_bands` function to project Hamiltonian tensors onto subspaces defined by eigenvalues close to a target value at specified k-points.
- [x] Enhanced error handling for input validation, ensuring correct tensor dimensions and types.
- [x] Added comprehensive test cases to validate the functionality of `nearest_bands`, covering various scenarios including single and multiple band selections, handling of explicit fractional coordinates, and error conditions for invalid inputs.
- [x] Updated import statements in the test module to include the new function.