### PR TITLE
Remove `U1Basis.rep`; canonicalize irreps in `base`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qten"
-version = "0.2.1"
+version = "0.2.2"
 description = "Torch-based tensors, lattices, symmetries, and band-structure tools for quantum lattice models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/qten/symbolics/hilbert_space.py
+++ b/src/qten/symbolics/hilbert_space.py
@@ -148,7 +148,7 @@ class U1Basis(
     [`U1Span`][qten.symbolics.hilbert_space.U1Span] of distinct
     [`U1Basis`][qten.symbolics.hilbert_space.U1Basis] values. Ordering (`<`,
     `>`) compares the number of irreps, then the tuple of fully-qualified irrep
-    type names (`module.qualname`) from `self.rep`, then the canonical
+    type names (`module.qualname`) from `self.base`, then the canonical
     irrep-value tuple itself. If irrep values of matching types are not
     orderable, the comparison raises from the underlying irrep objects.
 
@@ -162,7 +162,7 @@ class U1Basis(
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
-            "rep",
+            "base",
             tuple(
                 sorted(
                     self.base,
@@ -290,7 +290,7 @@ class U1Basis(
         """
         Return the unique irrep in this state whose concrete type is `T`.
 
-        This method performs a direct scan over `self.rep` and returns the
+        This method performs a direct scan over `self.base` and returns the
         first irrep satisfying `type(irrep) is T`. Because
         `U1Basis.__post_init__` enforces unity multiplicity for each irrep
         type, the match is unique whenever it exists.
@@ -427,7 +427,7 @@ class U1Basis(
         """
         Get a tuple of concrete irrep types in this [`U1Basis`][qten.symbolics.hilbert_space.U1Basis] in canonical order.
 
-        This is the same order as `self.rep`, which is determined by
+        This is the same order as `self.base`, which is determined by
         sorting on [`full_typename(type(irrep))`][qten.utils.types_ext.full_typename].
 
         Returns

--- a/tests/test_hilbert.py
+++ b/tests/test_hilbert.py
@@ -63,7 +63,7 @@ def test_u1_state_irrep_access_and_replace():
 
     replaced = psi.replace(r1)
     assert replaced.irrep_of(Offset) == r1
-    assert replaced.rep[1] == Orb("p")
+    assert replaced.base[1] == Orb("p")
 
 
 def test_u1_state_rejects_non_unity_type_multiplicity():

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -1426,9 +1426,7 @@ def test_kernel_tensor_builds_rank2_tensor_from_kernel():
     left = _simple_hilbert("left", 3)
     right = _simple_hilbert("right", 2)
 
-    out = kernel_tensor(
-        lambda x, y: x.base[0][1] - 10 * y.base[0][1], (left, right)
-    )
+    out = kernel_tensor(lambda x, y: x.base[0][1] - 10 * y.base[0][1], (left, right))
 
     expected = torch.tensor(
         [[0, -10], [1, -9], [2, -8]],

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -1426,7 +1426,9 @@ def test_kernel_tensor_builds_rank2_tensor_from_kernel():
     left = _simple_hilbert("left", 3)
     right = _simple_hilbert("right", 2)
 
-    out = kernel_tensor(lambda x, y: x.rep[0][1] - 10 * y.rep[0][1], (left, right))
+    out = kernel_tensor(
+        lambda x, y: x.base[0][1] - 10 * y.base[0][1], (left, right)
+    )
 
     expected = torch.tensor(
         [[0, -10], [1, -9], [2, -8]],
@@ -1443,7 +1445,7 @@ def test_kernel_tensor_builds_rank3_tensor_from_kernel():
     c = _simple_hilbert("c", 2)
 
     out = kernel_tensor(
-        lambda x, y, z: x.rep[0][1] + 2 * y.rep[0][1] + 3 * z.rep[0][1],
+        lambda x, y, z: x.base[0][1] + 2 * y.base[0][1] + 3 * z.base[0][1],
         (a, b, c),
     )
 
@@ -1451,7 +1453,7 @@ def test_kernel_tensor_builds_rank3_tensor_from_kernel():
     for i, x in enumerate(a.elements()):
         for j, y in enumerate(b.elements()):
             for k, z in enumerate(c.elements()):
-                expected[i, j, k] = x.rep[0][1] + 2 * y.rep[0][1] + 3 * z.rep[0][1]
+                expected[i, j, k] = x.base[0][1] + 2 * y.base[0][1] + 3 * z.base[0][1]
 
     assert out.dims == (a, b, c)
     assert torch.equal(out.data, expected)


### PR DESCRIPTION
## Description
- `U1Basis` now **canonicalizes irreps by sorting `base` in `__post_init__`**, so newly created `U1Basis` instances always have a deterministic `base` order.
- Removed the need for a separate `rep` attribute by **switching call sites to use `base`** as the canonical representation.
- Updated `U1Basis` documentation to refer to `base` (not `rep`) as the canonical ordering source.

## Details
- **Behavior change**: `U1Basis.new(...)` (and any direct construction) now yields a `U1Basis` whose `base` tuple is already sorted by `full_typename(type(irrep))`.
- **Refactor**: Updated tests and kernel examples that previously indexed `x.rep[...]` to index `x.base[...]` instead.
