### PR TITLE
Enhance `nearest_bands` function to optionally return anchor basis

### DIFF
--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -1033,7 +1033,8 @@ def nearest_bands(
     close_to: float = 0.0,
     tol: float = 1e-6,
     points: Optional[Dict[str, Sequence[float]]] = None,
-) -> Tensor:
+    return_basis: bool = False,
+) -> Union[Tensor, Tuple[Tensor, Tensor]]:
     r"""
     Project a momentum-resolved Hamiltonian onto bands selected at one k-point.
 
@@ -1042,6 +1043,9 @@ def nearest_bands(
     collected into a rectangular matrix \(V\). If the input Hilbert dimension is
     \(N\) and \(S\) bands are selected, then `V` has shape `(N, S)` and the
     returned tensor stores \(V^\dagger H(k) V\) for every momentum \(k\).
+    When `return_basis=True`, the function also returns \(V\) as a tensor so
+    projected eigenvectors can be lifted back to the original Hilbert-space
+    basis.
 
     Projection convention
     ---------------------
@@ -1089,15 +1093,23 @@ def nearest_bands(
         Half-width of the eigenvalue window around `close_to`.
     points : dict[str, Sequence[float]], optional
         Mapping from labels to fractional coordinates.
+    return_basis : bool, default=False
+        If `True`, also return the selected anchor eigenvector matrix \(V\)
+        with dims
+        ([`HilbertSpace`][qten.symbolics.hilbert_space.HilbertSpace],
+        [`IndexSpace`][qten.symbolics.state_space.IndexSpace]).
 
     Returns
     -------
-    Tensor
+    Tensor or tuple[Tensor, Tensor]
         Projected Hamiltonian with dims
         ([`MomentumSpace`][qten.symbolics.state_space.MomentumSpace],
         [`IndexSpace`][qten.symbolics.state_space.IndexSpace],
         [`IndexSpace`][qten.symbolics.state_space.IndexSpace]). The last two
-        axes span the selected subspace.
+        axes span the selected subspace. If `return_basis=True`, the second
+        return value is the selected anchor basis \(V\), with dims
+        ([`HilbertSpace`][qten.symbolics.hilbert_space.HilbertSpace],
+        [`IndexSpace`][qten.symbolics.state_space.IndexSpace]).
 
     Raises
     ------
@@ -1171,4 +1183,8 @@ def nearest_bands(
     projected = torch.einsum("ia,kab,bj->kij", V_dag, h_k.data, V)
 
     out_space = IndexSpace.linear(n_selected)
-    return Tensor(data=projected, dims=(kspace, out_space, out_space))
+    projected_tensor = Tensor(data=projected, dims=(kspace, out_space, out_space))
+    if return_basis:
+        basis_tensor = Tensor(data=V, dims=(h_k.dims[1], out_space))
+        return projected_tensor, basis_tensor
+    return projected_tensor

--- a/tests/test_bands.py
+++ b/tests/test_bands.py
@@ -9,6 +9,7 @@ from qten.bands import (
     bandselect,
     interpolate_path,
 )
+from qten.linalg import eigh
 from qten.geometries.boundary import PeriodicBoundary
 from qten.geometries.spatials import Lattice
 from qten.linalg.tensors import Tensor
@@ -370,6 +371,47 @@ def test_bands_near_value_empty_subspace_when_no_match():
     assert result.dims[1].dim == 0
     assert result.dims[2].dim == 0
     assert result.data.shape == (2, 0, 0)
+
+
+def test_bands_near_value_can_return_anchor_basis():
+    tensor, band_space = _band_tensor()
+
+    result, basis = nearest_bands(
+        tensor,
+        point="Gamma",
+        close_to=-1.0,
+        tol=1e-6,
+        return_basis=True,
+    )
+
+    assert result.dims[0] == tensor.dims[0]
+    assert basis.dims[0] == band_space
+    assert basis.dims[1] == result.dims[1]
+    assert basis.data.shape == (band_space.dim, 1)
+    expected_basis = torch.eye(4, dtype=torch.complex128)[:, 1:2]
+    assert torch.allclose(basis.data, expected_basis)
+
+
+def test_bands_near_value_basis_lifts_projected_vectors_for_all_k():
+    tensor, band_space = _band_tensor()
+
+    projected, basis = nearest_bands(
+        tensor,
+        point="Gamma",
+        close_to=0.5,
+        tol=1.6,
+        return_basis=True,
+    )
+    _values, coeffs = eigh(projected)
+
+    lifted = basis @ coeffs
+    first_k = lifted[0]
+
+    assert lifted.dims[0] == tensor.dims[0]
+    assert lifted.dims[1] == band_space
+    assert isinstance(lifted.dims[2], IndexSpace)
+    assert first_k.dims[0] == band_space
+    assert first_k.dims[1] == lifted.dims[2]
 
 
 def test_bands_near_value_non_diagonal_projection_math():


### PR DESCRIPTION
- Updated the `nearest_bands` function to include a new parameter `return_basis`, allowing users to retrieve the selected anchor eigenvector matrix \(V\) alongside the projected Hamiltonian.
- Modified the function's return type to accommodate the new output structure, which can now return either a single tensor or a tuple of tensors.
- Enhanced documentation to clarify the new parameter and its implications for the output.
- Added tests to validate the functionality of returning the anchor basis, ensuring correct dimensions and data integrity for the returned tensors.