### PR TITLE
Added Lattice extraction support for `MomentumSpace`

### DIFF
--- a/src/qten/symbolics/state_space.py
+++ b/src/qten/symbolics/state_space.py
@@ -465,6 +465,14 @@ class MomentumSpace(StateSpace[Momentum]):
     keys are [`Momentum`][qten.geometries.spatials.Momentum] objects and its
     values are the corresponding integer basis indices.
 
+    Extraction
+    ----------
+    When all stored momenta belong to one reciprocal lattice,
+    [`StateSpace.extract`][qten.symbolics.state_space.StateSpace.extract]
+    supports extracting both that
+    [`ReciprocalLattice`][qten.geometries.spatials.ReciprocalLattice] and its
+    dual [`Lattice`][qten.geometries.spatials.Lattice].
+
     Notes
     -----
     The class inherits the custom hashing behavior from

--- a/src/qten/symbolics/state_space.py
+++ b/src/qten/symbolics/state_space.py
@@ -28,7 +28,7 @@ from multimethod import multimethod
 
 from ..abstracts import Convertible, Operable, Span
 from ..validations import need_validation
-from ..geometries import Momentum, ReciprocalLattice
+from ..geometries import Lattice, Momentum, ReciprocalLattice
 from ..geometries.spatials import Spatial
 
 
@@ -714,6 +714,33 @@ def _(space: MomentumSpace, _: type[ReciprocalLattice]) -> ReciprocalLattice:
         raise ValueError("MomentumSpace does not have a unique ReciprocalLattice")
 
     return reciprocal_lattices.pop()
+
+
+@StateSpace.extract.register
+def _(space: MomentumSpace, _: type[Lattice]) -> Lattice:
+    """
+    Extract the unique direct lattice dual to the shared reciprocal lattice.
+
+    Parameters
+    ----------
+    space : MomentumSpace
+        Momentum space whose elements should share one reciprocal lattice.
+    _ : type[Lattice]
+        Extraction target type.
+
+    Returns
+    -------
+    Lattice
+        The unique direct lattice dual to the reciprocal lattice used by every
+        momentum in `space`.
+
+    Raises
+    ------
+    ValueError
+        If the space is empty or contains momenta from multiple reciprocal
+        lattices.
+    """
+    return space.extract(ReciprocalLattice).dual
 
 
 @lru_cache

--- a/src/qten/symbolics/state_space.pyi
+++ b/src/qten/symbolics/state_space.pyi
@@ -1,5 +1,6 @@
 from ..abstracts import Convertible as Convertible, Span as Span
 from ..geometries.spatials import (
+    Lattice as Lattice,
     Momentum as Momentum,
     ReciprocalLattice as ReciprocalLattice,
     Spatial as Spatial,

--- a/tests/test_hilbert.py
+++ b/tests/test_hilbert.py
@@ -493,6 +493,7 @@ def test_momentum_space_brillouin():
     ms = brillouin_zone(recip)
     assert isinstance(ms, MomentumSpace)
     assert ms.dim == 4
+    assert ms.extract(Lattice) == lat
     assert ms.extract(ReciprocalLattice) is recip
 
     assert str(ms) == "MomentumSpace(4)"
@@ -504,6 +505,9 @@ def test_momentum_space_extract_reciprocal_lattice_rejects_empty_space():
 
     with pytest.raises(ValueError, match="MomentumSpace is empty"):
         ms.extract(ReciprocalLattice)
+
+    with pytest.raises(ValueError, match="MomentumSpace is empty"):
+        ms.extract(Lattice)
 
 
 def test_momentum_space_extract_reciprocal_lattice_requires_uniqueness():
@@ -518,6 +522,11 @@ def test_momentum_space_extract_reciprocal_lattice_requires_uniqueness():
         ValueError, match="MomentumSpace does not have a unique ReciprocalLattice"
     ):
         ms.extract(ReciprocalLattice)
+
+    with pytest.raises(
+        ValueError, match="MomentumSpace does not have a unique ReciprocalLattice"
+    ):
+        ms.extract(Lattice)
 
 
 def test_statespace_type_errors():


### PR DESCRIPTION
See #143 

## Description
`MomentumSpace.extract(Lattice)` now returns the direct lattice dual to the space's unique reciprocal lattice. This reuses the existing reciprocal-lattice extraction path, so empty spaces and mixed reciprocal lattices still raise the same validation errors. Tests were added to cover successful lattice extraction and the existing failure modes.