### PR TITLE
Fix skew `"bandstructure"` surface plotting in rotated frames

### DIFF
--- a/ext/plots/pyproject.toml
+++ b/ext/plots/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qten-plots"
-version = "0.2.1"
+version = "0.3.0"
 description = "Plotting extension for qten"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ext/plots/pyproject.toml
+++ b/ext/plots/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qten-plots"
-version = "0.2.0"
+version = "0.2.1"
 description = "Plotting extension for qten"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -19,6 +19,7 @@ from ._utils import (
     interpolate_path_on_grid,
     pointcloud_marker_for_mpl,
     pointcloud_size_for_mpl,
+    triangulate_surface_points,
     unwrap_periodic_offsets,
 )
 from .plottables import PointCloud
@@ -886,25 +887,59 @@ def plot_bandstructure_mpl(
         surface_k_cart = k_cart[surface_order]
         surface_eigvals = eigvals_np[surface_order]
 
-        evals_grid = surface_eigvals.reshape(recip.shape[0], recip.shape[1], n_bands)
-        if hide_nullspace:
-            evals_grid = evals_grid.copy()
-            evals_grid[np.abs(evals_grid) <= nullspace_tol] = np.nan
-
-        KX = surface_k_cart[:, 0].reshape(recip.shape[0], recip.shape[1])
-        KY = surface_k_cart[:, 1].reshape(recip.shape[0], recip.shape[1])
-
         cmap = kwargs.get("cmap", "viridis")
         surface_alpha = kwargs.get("surface_alpha", 0.85)
-        for b in range(n_bands):
-            ax.plot_surface(
-                KX,
-                KY,
-                evals_grid[:, :, b],
-                cmap=cmap,
-                alpha=surface_alpha,
-                linewidth=0,
-                antialiased=True,
+        use_rect_surface = recip.lattice.boundaries.basis.is_diagonal()
+        if use_rect_surface:
+            evals_grid = surface_eigvals.reshape(
+                recip.shape[0], recip.shape[1], n_bands
+            )
+            if hide_nullspace:
+                evals_grid = evals_grid.copy()
+                evals_grid[np.abs(evals_grid) <= nullspace_tol] = np.nan
+
+            KX = surface_k_cart[:, 0].reshape(recip.shape[0], recip.shape[1])
+            KY = surface_k_cart[:, 1].reshape(recip.shape[0], recip.shape[1])
+
+            for b in range(n_bands):
+                ax.plot_surface(
+                    KX,
+                    KY,
+                    evals_grid[:, :, b],
+                    cmap=cmap,
+                    alpha=surface_alpha,
+                    linewidth=0,
+                    antialiased=True,
+                )
+        else:
+            triangles = triangulate_surface_points(surface_k_cart[:, :2])
+            finite_evals = []
+            for b in range(n_bands):
+                band_z = surface_eigvals[:, b].copy()
+                if hide_nullspace:
+                    band_z[np.abs(band_z) <= nullspace_tol] = np.nan
+                valid_triangles = (
+                    triangles[np.all(np.isfinite(band_z)[triangles], axis=1)]
+                    if triangles.size > 0
+                    else np.empty((0, 3), dtype=int)
+                )
+                if valid_triangles.size == 0:
+                    continue
+                finite_evals.append(band_z[np.isfinite(band_z)])
+                ax.plot_trisurf(
+                    surface_k_cart[:, 0],
+                    surface_k_cart[:, 1],
+                    band_z,
+                    triangles=valid_triangles,
+                    cmap=cmap,
+                    alpha=surface_alpha,
+                    linewidth=0,
+                    antialiased=True,
+                )
+            KX = surface_k_cart[:, 0]
+            KY = surface_k_cart[:, 1]
+            evals_grid = (
+                np.concatenate(finite_evals) if finite_evals else np.array([0.0])
             )
 
         ax.set_title(title)

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -20,6 +20,7 @@ from ._utils import (
     compute_bonds,
     interpolate_path_on_grid,
     pointcloud_marker_for_plotly,
+    triangulate_surface_points,
     unwrap_periodic_offsets,
 )
 from .plottables import PointCloud
@@ -1092,27 +1093,69 @@ def plot_bandstructure(
             )
         surface_k_cart = k_cart[surface_order]
         surface_eigvals = eigvals_np[surface_order]
+        use_rect_surface = recip.lattice.boundaries.basis.is_diagonal()
 
-        KX = surface_k_cart[:, 0].reshape(nx, ny)
-        KY = surface_k_cart[:, 1].reshape(nx, ny)
-        evals_grid = surface_eigvals.reshape(nx, ny, n_bands)
-        if hide_nullspace:
-            evals_grid = evals_grid.copy()
-            evals_grid[np.abs(evals_grid) <= nullspace_tol] = np.nan
+        if use_rect_surface:
+            KX = surface_k_cart[:, 0].reshape(nx, ny)
+            KY = surface_k_cart[:, 1].reshape(nx, ny)
+            evals_grid = surface_eigvals.reshape(nx, ny, n_bands)
+            if hide_nullspace:
+                evals_grid = evals_grid.copy()
+                evals_grid[np.abs(evals_grid) <= nullspace_tol] = np.nan
 
-        for b in range(n_bands):
-            fig.add_trace(
-                go.Surface(
-                    x=KX,
-                    y=KY,
-                    z=evals_grid[:, :, b],
-                    name=f"Band {b}",
-                    showscale=(b == 0),
-                    colorscale="Viridis",
-                    opacity=0.9,
-                    hovertemplate="kx: %{x:.2f}<br>ky: %{y:.2f}<br>E: %{z:.3f}<extra></extra>",
+            for b in range(n_bands):
+                fig.add_trace(
+                    go.Surface(
+                        x=KX,
+                        y=KY,
+                        z=evals_grid[:, :, b],
+                        name=f"Band {b}",
+                        showscale=(b == 0),
+                        colorscale="Viridis",
+                        opacity=0.9,
+                        hovertemplate="kx: %{x:.2f}<br>ky: %{y:.2f}<br>E: %{z:.3f}<extra></extra>",
+                    )
                 )
-            )
+        else:
+            triangles = triangulate_surface_points(surface_k_cart[:, :2])
+            for b in range(n_bands):
+                band_z = surface_eigvals[:, b].copy()
+                if hide_nullspace:
+                    band_z[np.abs(band_z) <= nullspace_tol] = np.nan
+                finite = np.isfinite(band_z)
+                if not np.any(finite):
+                    continue
+
+                valid_triangles = (
+                    triangles[np.all(finite[triangles], axis=1)]
+                    if triangles.size > 0
+                    else np.empty((0, 3), dtype=int)
+                )
+                if valid_triangles.size == 0:
+                    continue
+
+                used_vertices = np.unique(valid_triangles.reshape(-1))
+                remap = np.full(len(band_z), -1, dtype=int)
+                remap[used_vertices] = np.arange(len(used_vertices), dtype=int)
+                remapped_triangles = remap[valid_triangles]
+
+                fig.add_trace(
+                    go.Mesh3d(
+                        x=surface_k_cart[used_vertices, 0],
+                        y=surface_k_cart[used_vertices, 1],
+                        z=band_z[used_vertices],
+                        i=remapped_triangles[:, 0],
+                        j=remapped_triangles[:, 1],
+                        k=remapped_triangles[:, 2],
+                        intensity=band_z[used_vertices],
+                        intensitymode="vertex",
+                        name=f"Band {b}",
+                        showscale=(b == 0),
+                        colorscale="Viridis",
+                        opacity=0.9,
+                        hovertemplate="kx: %{x:.2f}<br>ky: %{y:.2f}<br>E: %{z:.3f}<extra></extra>",
+                    )
+                )
 
     else:
         # === 1D Line Plot ===

--- a/ext/plots/src/qten_plots/_utils.py
+++ b/ext/plots/src/qten_plots/_utils.py
@@ -2,7 +2,7 @@ from typing import Optional, Sequence, Tuple
 
 import numpy as np
 import torch
-from scipy.spatial import cKDTree
+from scipy.spatial import Delaunay, cKDTree
 
 from qten.geometries.boundary import PeriodicBoundary
 from qten.geometries.spatials import Lattice, Offset, ReciprocalLattice
@@ -231,6 +231,23 @@ def analyze_bandstructure_sampling(
         effective_dim,
         surface_order,
     )
+
+
+def triangulate_surface_points(points_2d: np.ndarray) -> np.ndarray:
+    """
+    Triangulate 2D sample coordinates for direct surface rendering.
+
+    This is used for skew or otherwise non-rectangular Brillouin-zone meshes
+    where reshaping points into an `(nx, ny)` index grid would connect the
+    wrong neighbors.
+    """
+    if points_2d.ndim != 2 or points_2d.shape[1] != 2:
+        raise ValueError(
+            f"Expected points_2d with shape (n_points, 2), got {points_2d.shape}."
+        )
+    if points_2d.shape[0] < 3:
+        return np.empty((0, 3), dtype=int)
+    return Delaunay(points_2d).simplices.astype(int, copy=False)
 
 
 def band_path_positions(k_space: MomentumSpace, k_cart: np.ndarray) -> np.ndarray:

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -46,10 +46,16 @@ def create_dummy_tensor(data_like):
 
 
 def _make_square_lattice_band_tensor(shape: tuple[int, int]) -> Tensor:
+    return _make_band_tensor_for_boundary(
+        PeriodicBoundary(sy.ImmutableDenseMatrix.diag(*shape))
+    )
+
+
+def _make_band_tensor_for_boundary(boundary: PeriodicBoundary) -> Tensor:
     basis = sy.ImmutableDenseMatrix([[1, 0.0], [0.0, 1]])
     lat = Lattice(
         basis=basis,
-        boundaries=PeriodicBoundary(sy.ImmutableDenseMatrix.diag(*shape)),
+        boundaries=boundary,
         unit_cell={"r": sy.ImmutableDenseMatrix([0, 0])},
     )
 
@@ -784,6 +790,23 @@ def test_bandstructure_plot_keeps_surface_mode_for_permuted_2d_k_mesh():
     assert isinstance(fig, go.Figure)
     assert len(fig.data) >= 1
     assert all(isinstance(trace, go.Surface) for trace in fig.data)
+
+
+def test_bandstructure_plot_uses_triangulated_surface_for_skew_2d_k_mesh():
+    h_k = _make_band_tensor_for_boundary(
+        PeriodicBoundary(sy.ImmutableDenseMatrix([[4, 1], [0, 4]]))
+    )
+
+    fig = h_k.plot(
+        "bandstructure",
+        backend="plotly",
+        title="Skew 2D Bandstructure",
+        show=False,
+    )
+
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) >= 1
+    assert all(isinstance(trace, go.Mesh3d) for trace in fig.data)
 
 
 def test_bandstructure_plot_auto_falls_back_to_path_for_effectively_1d_k_mesh():


### PR DESCRIPTION
See #144 

## Fix description
Use direct triangulation for skew/non-diagonal 2D k-meshes instead of forcing them through a rectangular reshape before plotting. This avoids striped patch artifacts in rotated-frame bandstructure surfaces while preserving the existing rectangular-surface path for axis-aligned meshes.

Also add regression coverage for skew 2D meshes in the plotting tests.