### PR TITLE
Add periodic bond wrapping support in plotting functions

### DIFF
--- a/docs/plot-methods.md
+++ b/docs/plot-methods.md
@@ -71,8 +71,14 @@ Inputs:
 | `color_by` | `str` | `basis` | `basis` colors by unit-cell site; `unit_cell` colors by translated cell. |
 | `highlights` | `Sequence[PointCloud]` | `None` | Styled point-cloud overlays. |
 | `use_lattice_coords` | `bool` | `False` | Show lattice-coordinate values in hover text where supported. |
-| `periodic_image_opacity` | `float` | `0.5` | Opacity for periodic highlight images, in the inclusive range `[0, 1]`. |
+| `show_periodic_wrap_bonds` | `bool` | `False` | For periodic lattices, include nearest-neighbor bonds that wrap across periodic boundaries. |
+| `periodic_image_opacity` | `float` | `0.5` | Opacity for periodic-image overlays, in the inclusive range `[0, 1]`. |
 | `**kwargs` | `object` | `{}` | Backend-specific figure options such as `figsize`, `cmap`, or line settings. |
+
+Notes:
+
+- `show_periodic_wrap_bonds` affects bond connectivity only (used with `plot_type="edge-and-node"`).
+- `periodic_image_opacity` affects periodic-image visibility only and does not change which bonds are selected.
 
 Plotly inputs:
 

--- a/docs/plot-methods.md
+++ b/docs/plot-methods.md
@@ -71,6 +71,7 @@ Inputs:
 | `color_by` | `str` | `basis` | `basis` colors by unit-cell site; `unit_cell` colors by translated cell. |
 | `highlights` | `Sequence[PointCloud]` | `None` | Styled point-cloud overlays. |
 | `use_lattice_coords` | `bool` | `False` | Show lattice-coordinate values in hover text where supported. |
+| `bond_mode` | `str` | `auto` | Bond-neighbor selection mode: `auto`, `nearest`, or `periodic`. |
 | `show_periodic_wrap_bonds` | `bool` | `False` | For periodic lattices, include nearest-neighbor bonds that wrap across periodic boundaries. |
 | `periodic_image_opacity` | `float` | `0.5` | Opacity for periodic-image overlays, in the inclusive range `[0, 1]`. |
 | `**kwargs` | `object` | `{}` | Backend-specific figure options such as `figsize`, `cmap`, or line settings. |
@@ -78,6 +79,8 @@ Inputs:
 Notes:
 
 - `show_periodic_wrap_bonds` affects bond connectivity only (used with `plot_type="edge-and-node"`).
+- `bond_mode="nearest"` forces nearest-neighbor bonds in plotted Cartesian coordinates.
+- `bond_mode="periodic"` requires periodic lattice metadata and enables periodic-aware bond selection.
 - `periodic_image_opacity` affects periodic-image visibility only and does not change which bonds are selected.
 
 Plotly inputs:

--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -102,6 +102,7 @@ def plot_structure_mpl(
     color_by: str = "basis",
     highlights: Sequence[PointCloud] | None = None,
     use_lattice_coords: bool = False,
+    show_periodic_wrap_bonds: bool = False,
     periodic_image_opacity: float = 0.5,
     **kwargs,
 ) -> plt.Figure:
@@ -148,6 +149,7 @@ def plot_structure_mpl(
         )
 
     coords = obj.cartes(torch.Tensor)
+    site_offsets = tuple(obj.cartes(Offset))
     coords_np = coords.numpy()
 
     x = coords_np[:, 0]
@@ -171,7 +173,13 @@ def plot_structure_mpl(
 
     # Bonds
     if plot_type == "edge-and-node":
-        x_lines, y_lines, z_lines = compute_bonds(coords, obj.dim)
+        x_lines, y_lines, z_lines = compute_bonds(
+            coords,
+            obj.dim,
+            lattice=obj,
+            offsets=site_offsets,
+            show_periodic_wrap_bonds=show_periodic_wrap_bonds,
+        )
         if len(x_lines) > 0:
             if is_3d and z_lines is not None:
                 ax.plot(

--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -128,6 +128,14 @@ def plot_structure_mpl(
         Existing axes to plot on.
     color_by : {'basis', 'unit_cell'}, default 'basis'
         How to color the sites.
+    show_periodic_wrap_bonds : bool, default False
+        Only relevant for periodic lattices. If True, bonds that cross periodic
+        boundaries are drawn as "wrapped" connections by considering neighboring
+        periodic images; if False, bonds are computed using the canonical site
+        representatives only.
+    periodic_image_opacity : float, default 0.5
+        Opacity used when plotting periodic images (when applicable). Must lie in
+        [0, 1].
     **kwargs
         Additional keyword arguments passed to `plt.figure` (e.g., `figsize`).
 

--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -3,7 +3,7 @@ import math
 import torch
 import numpy as np
 import matplotlib.pyplot as plt
-from typing import Optional, Union, Any, cast, Tuple, Sequence
+from typing import Literal, Optional, Union, Any, cast, Tuple, Sequence
 from qten.geometries.boundary import PeriodicBoundary
 from qten.geometries.spatials import Lattice, Offset
 from qten.linalg.tensors import Tensor
@@ -102,6 +102,7 @@ def plot_structure_mpl(
     color_by: str = "basis",
     highlights: Sequence[PointCloud] | None = None,
     use_lattice_coords: bool = False,
+    bond_mode: Literal["auto", "nearest", "periodic"] = "auto",
     show_periodic_wrap_bonds: bool = False,
     periodic_image_opacity: float = 0.5,
     **kwargs,
@@ -128,6 +129,10 @@ def plot_structure_mpl(
         Existing axes to plot on.
     color_by : {'basis', 'unit_cell'}, default 'basis'
         How to color the sites.
+    bond_mode : {'auto', 'nearest', 'periodic'}, default 'auto'
+        Bond-neighbor selection mode. ``auto`` uses periodic metadata when
+        available and otherwise falls back to nearest-neighbor bonds in the
+        plotted Cartesian coordinates.
     show_periodic_wrap_bonds : bool, default False
         Only relevant for periodic lattices. If True, bonds that cross periodic
         boundaries are drawn as "wrapped" connections by considering neighboring
@@ -151,6 +156,9 @@ def plot_structure_mpl(
     valid_color_by = ["basis", "unit_cell"]
     if color_by not in valid_color_by:
         raise ValueError(f"Invalid color_by '{color_by}'. Options: {valid_color_by}")
+    valid_bond_modes = ["auto", "nearest", "periodic"]
+    if bond_mode not in valid_bond_modes:
+        raise ValueError(f"Invalid bond_mode '{bond_mode}'. Options: {valid_bond_modes}")
     if not (0.0 <= periodic_image_opacity <= 1.0):
         raise ValueError(
             f"periodic_image_opacity must lie in [0, 1], got {periodic_image_opacity}."
@@ -186,6 +194,7 @@ def plot_structure_mpl(
             obj.dim,
             lattice=obj,
             offsets=site_offsets,
+            bond_mode=bond_mode,
             show_periodic_wrap_bonds=show_periodic_wrap_bonds,
         )
         if len(x_lines) > 0:

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Tuple, Sequence, cast
+from typing import Literal, Optional, Union, Tuple, Sequence, cast
 import colorsys
 import math
 
@@ -142,6 +142,7 @@ def plot_structure(
     color_by: str = "basis",
     highlights: Sequence[PointCloud] | None = None,
     use_lattice_coords: bool = False,
+    bond_mode: Literal["auto", "nearest", "periodic"] = "auto",
     show_periodic_wrap_bonds: bool = False,
     periodic_image_opacity: float = 0.5,
     **kwargs,
@@ -166,6 +167,10 @@ def plot_structure(
         Existing figure to add traces to.
     color_by : {'basis', 'unit_cell'}, default 'basis'
         How to color the sites.
+    bond_mode : {'auto', 'nearest', 'periodic'}, default 'auto'
+        Bond-neighbor selection mode. ``auto`` uses periodic metadata when
+        available and otherwise falls back to nearest-neighbor bonds in the
+        plotted Cartesian coordinates.
     show_periodic_wrap_bonds : bool, default False
         Only relevant for periodic lattices. If True, bonds that cross periodic
         boundaries are drawn as "wrapped" connections by considering neighboring
@@ -189,6 +194,9 @@ def plot_structure(
     valid_color_by = ["basis", "unit_cell"]
     if color_by not in valid_color_by:
         raise ValueError(f"Invalid color_by '{color_by}'. Options: {valid_color_by}")
+    valid_bond_modes = ["auto", "nearest", "periodic"]
+    if bond_mode not in valid_bond_modes:
+        raise ValueError(f"Invalid bond_mode '{bond_mode}'. Options: {valid_bond_modes}")
     if not (0.0 <= periodic_image_opacity <= 1.0):
         raise ValueError(
             f"periodic_image_opacity must lie in [0, 1], got {periodic_image_opacity}."
@@ -219,6 +227,7 @@ def plot_structure(
             obj.dim,
             lattice=obj,
             offsets=ordered_site_offsets,
+            bond_mode=bond_mode,
             show_periodic_wrap_bonds=show_periodic_wrap_bonds,
         )
         if len(x_lines) > 0:

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -142,6 +142,7 @@ def plot_structure(
     color_by: str = "basis",
     highlights: Sequence[PointCloud] | None = None,
     use_lattice_coords: bool = False,
+    show_periodic_wrap_bonds: bool = False,
     periodic_image_opacity: float = 0.5,
     **kwargs,
 ) -> go.Figure:
@@ -186,6 +187,7 @@ def plot_structure(
         )
 
     coords = obj.cartes(torch.Tensor)
+    ordered_site_offsets = tuple(obj.cartes(Offset))
     coords_np = coords.numpy()
     site_offsets = _lattice_site_offsets(obj)
     hovertext = [
@@ -204,7 +206,13 @@ def plot_structure(
         fig = go.Figure()
     # Bonds (Only for 'edge-and-node')
     if plot_type == "edge-and-node":
-        x_lines, y_lines, z_lines = compute_bonds(coords, obj.dim)
+        x_lines, y_lines, z_lines = compute_bonds(
+            coords,
+            obj.dim,
+            lattice=obj,
+            offsets=ordered_site_offsets,
+            show_periodic_wrap_bonds=show_periodic_wrap_bonds,
+        )
         if len(x_lines) > 0:
             bond_kwargs: dict = dict(
                 x=x_lines,

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -166,6 +166,14 @@ def plot_structure(
         Existing figure to add traces to.
     color_by : {'basis', 'unit_cell'}, default 'basis'
         How to color the sites.
+    show_periodic_wrap_bonds : bool, default False
+        Only relevant for periodic lattices. If True, bonds that cross periodic
+        boundaries are drawn as "wrapped" connections by considering neighboring
+        periodic images; if False, bonds are computed using the canonical site
+        representatives only.
+    periodic_image_opacity : float, default 0.5
+        Opacity used when plotting periodic images (when applicable). Must lie in
+        [0, 1].
     **kwargs
         Additional keyword arguments passed to `go.Figure`.
 

--- a/ext/plots/src/qten_plots/_utils.py
+++ b/ext/plots/src/qten_plots/_utils.py
@@ -95,11 +95,14 @@ def compute_bonds(
     """
     Generate bond lines connecting nearest neighbors.
 
-    When lattice metadata is provided, nearest neighbors are determined with a
-    periodic-aware KDTree search performed in numeric Cartesian coordinates.
-    This avoids false negatives for bonds crossing periodic boundaries while
-    keeping runtime close to the non-periodic KDTree path. Without lattice
-    metadata, a KDTree fallback is used.
+    Without lattice metadata, nearest neighbors are determined via a KDTree-based
+    search in numeric Cartesian coordinates.
+
+    When lattice metadata is provided for a periodic lattice, neighboring
+    periodic images can be considered (controlled by
+    ``show_periodic_wrap_bonds``), so nearest-neighbor connections that cross
+    periodic boundaries are not missed. This uses a KDTree built over translated
+    periodic images rather than a dense all-pairs distance matrix.
 
     Returns (x_lines, y_lines, z_lines) where arrays contain coordinates
     separated by NaN (line-break sentinel for both Plotly and Matplotlib).
@@ -147,36 +150,75 @@ def compute_bonds(
             else:
                 shift_coeffs = np.zeros((1, lattice.dim), dtype=np.float64)
             shift_cart = shift_coeffs @ physical_boundaries.T
-            delta_cart_base = pts[None, :, :] - pts[:, None, :]
+            aug_pts = (pts[None, :, :] + shift_cart[:, None, :]).reshape(-1, n_cols)
+            aug_orig_idx = np.tile(np.arange(n, dtype=np.int64), len(shift_cart))
 
-            best_norm2 = np.full((n, n), np.inf, dtype=np.float64)
-            best_disp = np.zeros((n, n, n_cols), dtype=np.float64)
-            for shift in shift_cart:
-                disp = delta_cart_base + shift.reshape(1, 1, -1)
-                norm2 = np.sum(disp * disp, axis=2)
-                mask = norm2 < best_norm2
-                if np.any(mask):
-                    best_norm2[mask] = norm2[mask]
-                    best_disp[mask] = disp[mask]
+            tree = cKDTree(aug_pts)
+            nearest = np.full(n, np.inf, dtype=np.float64)
+            initial_k = min(max(8, 2 * len(shift_cart)), aug_pts.shape[0])
+            for i in range(n):
+                k = initial_k
+                while True:
+                    dists, idxs = tree.query(pts[i], k=k)
+                    dists_arr = np.atleast_1d(np.asarray(dists, dtype=np.float64))
+                    idxs_arr = np.atleast_1d(np.asarray(idxs, dtype=np.int64))
 
-            np.fill_diagonal(best_norm2, np.inf)
-            min_dists = np.sqrt(best_norm2)
-            nearest = np.min(min_dists, axis=1)
+                    non_self = aug_orig_idx[idxs_arr] != i
+                    if np.any(non_self):
+                        nearest[i] = float(np.min(dists_arr[non_self]))
+                        break
+                    if k >= aug_pts.shape[0]:
+                        break
+                    k = min(aug_pts.shape[0], k * 2)
+
             finite_nearest = nearest[np.isfinite(nearest)]
             if finite_nearest.size == 0:
                 return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
 
-            nearest_pair_cutoff = np.minimum.outer(nearest, nearest)
-            shell_tol = np.maximum(
-                nearest_abs_tol, nearest_rel_tol * np.maximum(nearest_pair_cutoff, 1.0)
+            tol_per_site = np.maximum(
+                nearest_abs_tol, nearest_rel_tol * np.maximum(nearest, 1.0)
             )
-            pair_mask = np.triu(min_dists <= nearest_pair_cutoff + shell_tol, k=1)
-            pair_i, pair_j = np.where(pair_mask)
-            if pair_i.size == 0:
+            pair_disp: dict[tuple[int, int], tuple[float, np.ndarray]] = {}
+
+            for i in range(n):
+                if not np.isfinite(nearest[i]):
+                    continue
+                radius = float(nearest[i] + tol_per_site[i])
+                candidate_idxs = tree.query_ball_point(pts[i], r=radius)
+                for cand in candidate_idxs:
+                    j = int(aug_orig_idx[cand])
+                    if j == i:
+                        continue
+
+                    disp_ij = aug_pts[cand] - pts[i]
+                    dist2 = float(np.dot(disp_ij, disp_ij))
+                    dist = float(np.sqrt(dist2))
+                    nearest_pair_cutoff = min(float(nearest[i]), float(nearest[j]))
+                    shell_tol = max(
+                        nearest_abs_tol,
+                        nearest_rel_tol * max(nearest_pair_cutoff, 1.0),
+                    )
+                    if dist > nearest_pair_cutoff + shell_tol:
+                        continue
+
+                    if i < j:
+                        key = (i, j)
+                        oriented_disp = disp_ij
+                    else:
+                        key = (j, i)
+                        oriented_disp = -disp_ij
+
+                    prev = pair_disp.get(key)
+                    if prev is None or dist2 < prev[0]:
+                        pair_disp[key] = (dist2, oriented_disp.copy())
+
+            if not pair_disp:
                 return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
 
+            ordered_pairs = sorted(pair_disp.keys())
+            pair_i = np.array([i for i, _ in ordered_pairs], dtype=np.int64)
             p1 = pts[pair_i]
-            p2 = p1 + best_disp[pair_i, pair_j]
+            p2 = np.stack([pts[i] + pair_disp[(i, j)][1] for i, j in ordered_pairs])
         else:
             tree = cKDTree(pts)
 

--- a/ext/plots/src/qten_plots/_utils.py
+++ b/ext/plots/src/qten_plots/_utils.py
@@ -1,3 +1,4 @@
+from itertools import product
 from typing import Optional, Sequence, Tuple
 
 import numpy as np
@@ -82,13 +83,23 @@ def pointcloud_size_for_mpl(size: float | None, *, default_area: float) -> float
 
 
 def compute_bonds(
-    coords: torch.Tensor, dim: int
+    coords: torch.Tensor,
+    dim: int,
+    *,
+    lattice: Lattice | None = None,
+    offsets: Sequence[Offset] | None = None,
+    show_periodic_wrap_bonds: bool = False,
+    nearest_rel_tol: float = 1e-6,
+    nearest_abs_tol: float = 1e-9,
 ) -> Tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
     """
     Generate bond lines connecting nearest neighbors.
 
-    Uses a KDTree for O(N log N) neighbor search instead of O(N²) pairwise
-    distances, making this feasible for large lattices (100k+ sites).
+    When lattice metadata is provided, nearest neighbors are determined with a
+    periodic-aware KDTree search performed in numeric Cartesian coordinates.
+    This avoids false negatives for bonds crossing periodic boundaries while
+    keeping runtime close to the non-periodic KDTree path. Without lattice
+    metadata, a KDTree fallback is used.
 
     Returns (x_lines, y_lines, z_lines) where arrays contain coordinates
     separated by NaN (line-break sentinel for both Plotly and Matplotlib).
@@ -100,22 +111,86 @@ def compute_bonds(
         return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
 
     pts = coords.numpy().astype(np.float64)
-    tree = cKDTree(pts)
-
-    dd, _ = tree.query(pts, k=2)
-    min_dist = float(dd[:, 1].min())
-    if np.isinf(min_dist):
-        return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
-
-    pairs = tree.query_pairs(r=min_dist + 1e-4, output_type="ndarray")
-    if len(pairs) == 0:
-        return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
-
-    p1 = pts[pairs[:, 0]]
-    p2 = pts[pairs[:, 1]]
-    n_bonds = len(pairs)
     n_cols = pts.shape[1]
 
+    if lattice is None or offsets is None:
+        tree = cKDTree(pts)
+
+        dd, _ = tree.query(pts, k=2)
+        min_dist = float(dd[:, 1].min())
+        if np.isinf(min_dist):
+            return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
+
+        pairs = tree.query_pairs(r=min_dist + 1e-4, output_type="ndarray")
+        if len(pairs) == 0:
+            return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
+
+        p1 = pts[pairs[:, 0]]
+        p2 = pts[pairs[:, 1]]
+    else:
+        if len(offsets) != n:
+            raise ValueError(
+                f"offset count {len(offsets)} does not match coordinate count {n}."
+            )
+
+        if isinstance(lattice.boundaries, PeriodicBoundary):
+            lattice_basis = np.array(lattice.basis.evalf(), dtype=np.float64)
+            boundary_basis = np.array(lattice.boundaries.basis.evalf(), dtype=np.float64)
+            physical_boundaries = lattice_basis @ boundary_basis
+            if show_periodic_wrap_bonds:
+                shift_coeffs = np.array(
+                    tuple(product((-1, 0, 1), repeat=lattice.dim)),
+                    dtype=np.float64,
+                )
+            else:
+                shift_coeffs = np.zeros((1, lattice.dim), dtype=np.float64)
+            shift_cart = shift_coeffs @ physical_boundaries.T
+            delta_cart_base = pts[None, :, :] - pts[:, None, :]
+
+            best_norm2 = np.full((n, n), np.inf, dtype=np.float64)
+            best_disp = np.zeros((n, n, n_cols), dtype=np.float64)
+            for shift in shift_cart:
+                disp = delta_cart_base + shift.reshape(1, 1, -1)
+                norm2 = np.sum(disp * disp, axis=2)
+                mask = norm2 < best_norm2
+                if np.any(mask):
+                    best_norm2[mask] = norm2[mask]
+                    best_disp[mask] = disp[mask]
+
+            np.fill_diagonal(best_norm2, np.inf)
+            min_dists = np.sqrt(best_norm2)
+            nearest = np.min(min_dists, axis=1)
+            finite_nearest = nearest[np.isfinite(nearest)]
+            if finite_nearest.size == 0:
+                return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
+
+            nearest_pair_cutoff = np.minimum.outer(nearest, nearest)
+            shell_tol = np.maximum(
+                nearest_abs_tol, nearest_rel_tol * np.maximum(nearest_pair_cutoff, 1.0)
+            )
+            pair_mask = np.triu(min_dists <= nearest_pair_cutoff + shell_tol, k=1)
+            pair_i, pair_j = np.where(pair_mask)
+            if pair_i.size == 0:
+                return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
+
+            p1 = pts[pair_i]
+            p2 = p1 + best_disp[pair_i, pair_j]
+        else:
+            tree = cKDTree(pts)
+
+            dd, _ = tree.query(pts, k=2)
+            min_dist = float(dd[:, 1].min())
+            if np.isinf(min_dist):
+                return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
+
+            pairs = tree.query_pairs(r=min_dist + 1e-4, output_type="ndarray")
+            if len(pairs) == 0:
+                return _empty, _empty.copy(), (_empty.copy() if dim == 3 else None)
+
+            p1 = pts[pairs[:, 0]]
+            p2 = pts[pairs[:, 1]]
+
+    n_bonds = p1.shape[0]
     segments = np.empty((n_bonds, 3, n_cols), dtype=np.float64)
     segments[:, 0, :] = p1
     segments[:, 1, :] = p2

--- a/ext/plots/src/qten_plots/_utils.py
+++ b/ext/plots/src/qten_plots/_utils.py
@@ -135,7 +135,9 @@ def compute_bonds(
 
         if isinstance(lattice.boundaries, PeriodicBoundary):
             lattice_basis = np.array(lattice.basis.evalf(), dtype=np.float64)
-            boundary_basis = np.array(lattice.boundaries.basis.evalf(), dtype=np.float64)
+            boundary_basis = np.array(
+                lattice.boundaries.basis.evalf(), dtype=np.float64
+            )
             physical_boundaries = lattice_basis @ boundary_basis
             if show_periodic_wrap_bonds:
                 shift_coeffs = np.array(

--- a/ext/plots/src/qten_plots/_utils.py
+++ b/ext/plots/src/qten_plots/_utils.py
@@ -1,5 +1,5 @@
 from itertools import product
-from typing import Optional, Sequence, Tuple
+from typing import Literal, Optional, Sequence, Tuple
 
 import numpy as np
 import torch
@@ -88,6 +88,7 @@ def compute_bonds(
     *,
     lattice: Lattice | None = None,
     offsets: Sequence[Offset] | None = None,
+    bond_mode: Literal["auto", "nearest", "periodic"] = "auto",
     show_periodic_wrap_bonds: bool = False,
     nearest_rel_tol: float = 1e-6,
     nearest_abs_tol: float = 1e-9,
@@ -108,6 +109,12 @@ def compute_bonds(
     separated by NaN (line-break sentinel for both Plotly and Matplotlib).
     z_lines is None when *dim* != 3.
     """
+    valid_bond_modes = {"auto", "nearest", "periodic"}
+    if bond_mode not in valid_bond_modes:
+        raise ValueError(
+            f"Invalid bond_mode {bond_mode!r}. Options: {sorted(valid_bond_modes)}."
+        )
+
     _empty = np.empty(0, dtype=np.float64)
     n = coords.size(0)
     if n < 2:
@@ -116,7 +123,15 @@ def compute_bonds(
     pts = coords.numpy().astype(np.float64)
     n_cols = pts.shape[1]
 
-    if lattice is None or offsets is None:
+    use_nearest_only = bond_mode == "nearest" or (
+        bond_mode == "auto" and (lattice is None or offsets is None)
+    )
+    if not use_nearest_only and (lattice is None or offsets is None):
+        raise ValueError(
+            "bond_mode='periodic' requires both lattice and offsets metadata."
+        )
+
+    if use_nearest_only:
         tree = cKDTree(pts)
 
         dd, _ = tree.query(pts, k=2)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -17,7 +17,7 @@ from qten.linalg.tensors import Tensor
 from qten.geometries.fourier import fourier_transform
 from qten.plottings import Plottable
 from qten_plots.plottables import PointCloud
-from qten_plots._utils import band_path_positions
+from qten_plots._utils import band_path_positions, compute_bonds
 
 
 @dataclass(frozen=True)
@@ -259,6 +259,38 @@ def test_plot_structure_2d_and_3d():
     assert isinstance(fig_3d, go.Figure)
     assert len(fig_2d.data) >= 1
     assert len(fig_3d.data) >= 1
+
+
+def test_compute_bonds_periodic_mode_requires_lattice_metadata():
+    coords = torch.tensor([[0.0, 0.0], [1.0, 0.0]], dtype=torch.float64)
+    with pytest.raises(ValueError, match="requires both lattice and offsets"):
+        compute_bonds(coords, dim=2, bond_mode="periodic")
+
+
+def test_plot_structure_accepts_explicit_nearest_bond_mode():
+    basis = sy.ImmutableDenseMatrix([[1, 0], [0, 1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(sy.ImmutableDenseMatrix.diag(3, 3)),
+        unit_cell={"r": sy.ImmutableDenseMatrix([0, 0])},
+    )
+
+    fig = lattice.plot("structure", show=False, bond_mode="nearest")
+
+    assert isinstance(fig, go.Figure)
+    assert len(fig.data) >= 1
+
+
+def test_plot_structure_rejects_invalid_bond_mode():
+    basis = sy.ImmutableDenseMatrix([[1, 0], [0, 1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(sy.ImmutableDenseMatrix.diag(3, 3)),
+        unit_cell={"r": sy.ImmutableDenseMatrix([0, 0])},
+    )
+
+    with pytest.raises(ValueError, match="Invalid bond_mode"):
+        lattice.plot("structure", show=False, bond_mode="invalid")
 
 
 def test_plot_structure_accepts_pointcloud_highlights():


### PR DESCRIPTION
## Summary
- Reworked `compute_bonds` in `ext/plots/src/qten_plots/_utils.py` to make periodic bond selection more robust and deterministic.
- Updated both structure plot backends (`_plotly_impl.py`, `_mpl_impl.py`) to pass lattice/offset metadata into bond computation.
- Added `show_periodic_wrap_bonds` (default `False`) to structure plotting so users can hide wrap-around seam bonds for cleaner finite-cell visuals, while still allowing torus-style wrap bonds when needed.

## Why
- Nearest-neighbor bond inference based only on geometric cutoff was fragile for periodic/multi-sublattice lattices (e.g. honeycomb/kagome), producing extra-looking seam artifacts.
- Users need a clean default visualization and an explicit switch for periodic wrap connectivity display.

## TODO
- [x] `kagome.plot("structure")` shows clean nearest-neighbor bonds without seam-wrap artifacts.
- [x] `kagome.plot("structure")` no longer shows spurious extra-looking bonds in default mode.
- [x] Verify both backends:
  - [x] `backend="plotly"`
  - [x] `backend="matplotlib"`
- [x] Quick performance sanity check on `shape=(12, 12)` `honeycomb` and `kagome` remains acceptable.