### PR TITLE
Fix bandstructure “knots” by interpolating `H(k)` along paths

### DIFF
--- a/ext/plots/pyproject.toml
+++ b/ext/plots/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qten-plots"
-version = "0.2.0"
+version = "0.3.0"
 description = "Plotting extension for qten"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ext/plots/src/qten_plots/_mpl_impl.py
+++ b/ext/plots/src/qten_plots/_mpl_impl.py
@@ -938,7 +938,9 @@ def plot_bandstructure_mpl(
             if k_space == bz_path.k_space:
                 plot_eigvals = eigvals_np[list(bz_path.path_order)]
             else:
-                plot_eigvals = interpolate_path_on_grid(bz_path, k_space, eigvals_np)
+                H_np = obj.data.detach().cpu().numpy()
+                H_interp = interpolate_path_on_grid(bz_path, k_space, H_np)
+                plot_eigvals = np.linalg.eigvalsh(H_interp)
         else:
             x_vals = band_path_positions(k_space, k_cart)
             plot_eigvals = eigvals_np

--- a/ext/plots/src/qten_plots/_plotly_impl.py
+++ b/ext/plots/src/qten_plots/_plotly_impl.py
@@ -1121,7 +1121,9 @@ def plot_bandstructure(
             if k_space == bz_path.k_space:
                 plot_eigvals = eigvals_np[list(bz_path.path_order)]
             else:
-                plot_eigvals = interpolate_path_on_grid(bz_path, k_space, eigvals_np)
+                H_np = obj.data.detach().cpu().numpy()
+                H_interp = interpolate_path_on_grid(bz_path, k_space, H_np)
+                plot_eigvals = np.linalg.eigvalsh(H_interp)
         else:
             x_vals = band_path_positions(k_space, k_cart)
             plot_eigvals = eigvals_np

--- a/ext/plots/src/qten_plots/_utils.py
+++ b/ext/plots/src/qten_plots/_utils.py
@@ -277,21 +277,21 @@ def _effective_dimensionality(points: np.ndarray, tol: float = 1e-12) -> int:
 def interpolate_path_on_grid(
     bz_path: BzPath,
     grid_k_space: MomentumSpace,
-    eigvals: np.ndarray,
+    data: np.ndarray,
 ) -> np.ndarray:
-    """Interpolate eigenvalues from a regular BZ grid onto a path.
+    """Interpolate data (e.g. eigenvalues or Hamiltonian matrices) from a regular BZ grid onto a path.
 
-    Uses trilinear interpolation with periodic padding so that bands are
+    Uses trilinear interpolation with periodic padding so that values are
     smooth even when path k-points fall between grid points.
 
-    Returns an array of shape ``(len(bz_path.path_order), n_bands)``.
+    Returns an array of shape ``(len(bz_path.path_order), *data.shape[1:])``.
     """
     from scipy.interpolate import RegularGridInterpolator
 
     grid_k_points = list(grid_k_space)
     grid_recip = grid_k_points[0].space
     dim = grid_recip.dim
-    n_bands = eigvals.shape[1]
+    trailing_shape = data.shape[1:]
 
     grid_fracs = np.array(
         [np.array(k.rep, dtype=float).flatten() for k in grid_k_points]
@@ -305,19 +305,19 @@ def interpolate_path_on_grid(
     shape = tuple(len(ax) for ax in axes)
 
     # Map each grid k-point to its (i, j, k, ...) position and fill the array.
-    evals_grid = np.empty((*shape, n_bands))
-    evals_grid[:] = np.nan
-    for frac, ev in zip(grid_fracs, eigvals):
+    data_grid = np.empty((*shape, *trailing_shape), dtype=data.dtype)
+    data_grid[:] = np.nan
+    for frac, val in zip(grid_fracs, data):
         idx = tuple(
             int(np.searchsorted(axes[d], round(frac[d], 10))) for d in range(dim)
         )
-        evals_grid[idx] = ev
+        data_grid[idx] = val
 
     # Pad one extra slice at the end of each axis (periodic copy of the
     # first slice) so interpolation wraps smoothly across the BZ boundary.
     for d in range(dim):
-        evals_grid = np.concatenate(
-            [evals_grid, np.take(evals_grid, [0], axis=d)], axis=d
+        data_grid = np.concatenate(
+            [data_grid, np.take(data_grid, [0], axis=d)], axis=d
         )
         axes[d] = np.append(axes[d], 1.0)
 
@@ -335,15 +335,21 @@ def interpolate_path_on_grid(
 
     path_fracs = path_fracs_unique[list(bz_path.path_order)] % 1.0
 
-    result = np.empty((len(bz_path.path_order), n_bands))
-    for b in range(n_bands):
+    result = np.empty((len(bz_path.path_order), *trailing_shape), dtype=data.dtype)
+    
+    # Flatten trailing dimensions to interpolate them
+    n_trailing = int(np.prod(trailing_shape))
+    data_grid_flat = data_grid.reshape(*[len(ax) for ax in axes], n_trailing)
+    result_flat = result.reshape(len(bz_path.path_order), n_trailing)
+
+    for b in range(n_trailing):
         interp = RegularGridInterpolator(
             tuple(axes),
-            evals_grid[..., b],
-            method="linear",
+            data_grid_flat[..., b],
+            method="cubic",
             bounds_error=False,
             fill_value=None,
         )
-        result[:, b] = interp(path_fracs)
+        result_flat[:, b] = interp(path_fracs)
 
-    return result
+    return result_flat.reshape(len(bz_path.path_order), *trailing_shape)


### PR DESCRIPTION
# Description

- Bandstructure path plots previously interpolated **sorted eigenvalues** from a BZ grid onto the requested `bz_path`, which can introduce artificial “knots”/wiggles near crossings and on coarse grids.
- This PR changes the path fallback to instead interpolate the **Hamiltonian matrix** \(H(k)\) onto the path and then compute eigenvalues with `eigvalsh`, which is much more stable across crossings and preserves smoothness.
- Generalizes `interpolate_path_on_grid` to support arbitrary trailing shapes (e.g. `(n, n)` matrix blocks, not just `(n_bands,)`) and switches interpolation to `RegularGridInterpolator(..., method="cubic")` for smoother results.

# Key changes
- `ext/plots/src/qten_plots/_utils.py`
  - Generalize `interpolate_path_on_grid(bz_path, grid_k_space, data)` to return shape `(len(path), *data.shape[1:])`.
  - Use cubic interpolation on periodically padded grid axes.
- `ext/plots/src/qten_plots/_plotly_impl.py`, `ext/plots/src/qten_plots/_mpl_impl.py`
  - In 1D path mode, when `k_space != bz_path.k_space`, interpolate `obj.data` (Hamiltonian) onto the path and compute `np.linalg.eigvalsh` on the interpolated matrices.




