### PR TITLE
Added `get_direct_transform` for abelian transform on column tensors

### DIFF
--- a/src/qten/ops.py
+++ b/src/qten/ops.py
@@ -36,6 +36,7 @@ Point-group operations
 - [`joint_abelian_basis()`][qten.pointgroups.ops.joint_abelian_basis]
 - [`abelian_column_symmetrize()`][qten.pointgroups.ops.abelian_column_symmetrize]
 - [`joint_abelian_column_symmetrize()`][qten.pointgroups.ops.joint_abelian_column_symmetrize]
+- [`get_direct_transform()`][qten.pointgroups.ops.get_direct_transform]
 
 Notes
 -----
@@ -67,6 +68,7 @@ from .symbolics import (
 from .bands import interpolate_path as interpolate_path
 from .pointgroups.ops import (
     abelian_column_symmetrize as abelian_column_symmetrize,
+    get_direct_transform as get_direct_transform,
     joint_abelian_basis as joint_abelian_basis,
     joint_abelian_column_symmetrize as joint_abelian_column_symmetrize,
 )

--- a/src/qten/pointgroups/__init__.py
+++ b/src/qten/pointgroups/__init__.py
@@ -28,5 +28,6 @@ from .abelian import (
     AbelianOpr as AbelianOpr,
 )
 from .ops import (
+    get_direct_transform as get_direct_transform,
     joint_abelian_basis as joint_abelian_basis,
 )

--- a/src/qten/pointgroups/abelian.py
+++ b/src/qten/pointgroups/abelian.py
@@ -128,7 +128,9 @@ class AbelianBasis(Spatial):
         Build an [`AbelianBasis`][qten.pointgroups.abelian.AbelianBasis] from a Euclidean representation vector.
 
         The input `rep` is first normalized to a canonical representative by
-        dividing through its first non-zero coefficient. The normalized vector
+        dividing through the magnitude of its first non-zero coefficient. This
+        preserves the overall sign/phase of that leading term while removing
+        pure magnitude. The normalized vector
         is then converted into the symbolic polynomial expression in
         [`euclidean_basis`][qten.pointgroups.abelian.AbelianGroup.euclidean_basis] and stored as both `expr` and canonical `rep` data
         of the resulting [`AbelianBasis`][qten.pointgroups.abelian.AbelianBasis].
@@ -150,8 +152,8 @@ class AbelianBasis(Spatial):
         -------
         AbelianBasis
             Canonicalized abelian basis function whose stored `rep` is the
-            normalized version of the input vector and whose `expr` is the
-            corresponding symbolic polynomial.
+            magnitude-normalized version of the input vector and whose `expr`
+            is the corresponding symbolic polynomial.
 
         Raises
         ------
@@ -160,7 +162,7 @@ class AbelianBasis(Spatial):
             coefficient available for normalization.
         """
         principle_term = next(x for x in rep if x != 0)
-        normalized = sy.ImmutableDenseMatrix(sy.simplify(rep / principle_term))
+        normalized = sy.ImmutableDenseMatrix(sy.simplify(rep / sy.Abs(principle_term)))
         expr = sy.simplify(normalized.dot(euclidean_basis))
         return cls(expr=expr, axes=axes, order=order, rep=normalized)
 

--- a/src/qten/pointgroups/ops.py
+++ b/src/qten/pointgroups/ops.py
@@ -18,7 +18,7 @@ Hilbert-space data. The group definitions themselves live in
 
 from itertools import product
 from math import prod
-from typing import Sequence, cast
+from typing import Any, Optional, Sequence, Tuple, cast
 
 import sympy as sy
 
@@ -27,9 +27,10 @@ from .abelian import (
     AbelianGroup,
     AbelianOpr,
 )
-from ..linalg.tensors import Tensor, cat, eye
-from ..symbolics import HilbertSpace, IndexSpace, U1Basis, hilbert_opr_repr
+from ..linalg.tensors import Tensor, cat, eye, mapping_matrix
+from ..symbolics import HilbertSpace, IndexSpace, Multiple, U1Basis, hilbert_opr_repr
 from ..utils.collections_ext import FrozenDict
+from ..utils.devices import Device
 
 
 def _same_phase(a: sy.Expr, b: sy.Expr) -> bool:
@@ -71,6 +72,87 @@ def _attach_degeneracy_tag(seed: U1Basis, index: int) -> U1Basis:
         return seed.replace(tag)
     except ValueError:
         return U1Basis(coef=seed.coef, base=seed.base + (tag,))
+
+
+def _transform_abelian_basis_direct(
+    opr: AbelianOpr, basis: AbelianBasis
+) -> Multiple[AbelianBasis]:
+    group = opr.g
+    if set(group.axes) != set(basis.axes):
+        raise ValueError(
+            f"Axes of AbelianGroup and AbelianBasis must match: {group.axes} != {basis.axes}"
+        )
+
+    transformed_rep = sy.ImmutableDenseMatrix(
+        group.euclidean_repr(basis.order) @ basis.rep
+    )
+    scale = next(entry for entry in transformed_rep if entry != 0)
+    transformed_basis = AbelianBasis.from_rep(
+        rep=transformed_rep,
+        euclidean_basis=group.euclidean_basis(basis.order),
+        axes=group.axes,
+        order=basis.order,
+    )
+    return Multiple(sy.Abs(scale), transformed_basis)
+
+
+def _ext_transform_basis(opr: AbelianOpr, psi: U1Basis) -> U1Basis:
+    new_coef: sy.Expr = psi.coef
+    new_base: Tuple[Any, ...] = tuple()
+    for rep in psi.base:
+        if isinstance(rep, AbelianBasis):
+            transformed = _transform_abelian_basis_direct(opr, rep)
+            new_coef *= transformed.coef
+            new_rep = transformed.base
+        elif opr.allows(rep):
+            ret = opr(rep)
+            if isinstance(ret, Multiple):
+                new_coef *= ret.coef
+                new_rep = ret.base
+            else:
+                new_rep = ret
+        else:
+            new_rep = rep
+        new_base += (new_rep,)
+    return U1Basis(new_coef, new_base)
+
+
+def get_direct_transform(
+    opr: AbelianOpr,
+    space: HilbertSpace,
+    *,
+    device: Optional[Device] = None,
+) -> Tensor:
+    r"""
+    Build the external basis-mapping tensor from a Hilbert space to its transformed image.
+
+    Unlike [`hilbert_opr_repr()`][qten.symbolics.ops.hilbert_opr_repr], this helper does not require `opr` to preserve the ray structure of
+    `space`. Instead it explicitly constructs the transformed output
+    [`HilbertSpace`][qten.symbolics.hilbert_space.HilbertSpace] and returns a one-hot mapping matrix with dims `(space, out_space)`.
+
+    When a basis state contains an [`AbelianBasis`][qten.pointgroups.abelian.AbelianBasis] irrep, that irrep is transformed directly in the Euclidean polynomial basis.
+    In particular, no eigen-phase is factored out. For example, a basis
+    function `x` rotated by `C4` is mapped to `y` in the output space rather
+    than left as `x` with a phase in the tensor data.
+
+    Parameters
+    ----------
+    opr : AbelianOpr
+        Point-group operator used to transform basis labels.
+    space : HilbertSpace
+        Input Hilbert space whose ordered basis defines the source axis.
+    device : Optional[Device], optional
+        Device on which to allocate the returned mapping tensor.
+
+    Returns
+    -------
+    Tensor
+        Rank-2 tensor with dimensions `(space, out_space)` and only `1`
+        numerical entries at the mapped basis positions.
+    """
+    transformed = {psi: _ext_transform_basis(opr, psi) for psi in space.elements()}
+    out_space = space.map(lambda psi: transformed[psi])
+    return mapping_matrix(space, out_space, transformed, device=device)
 
 
 def joint_abelian_basis(

--- a/tests/test_abelian.py
+++ b/tests/test_abelian.py
@@ -82,6 +82,19 @@ def test_affine_function_dim_and_str():
     assert repr(f) == "x"
 
 
+def test_abelian_basis_from_rep_normalizes_magnitude_but_keeps_sign():
+    x = sy.symbols("x")
+    basis = AbelianBasis.from_rep(
+        rep=ImmutableDenseMatrix([-2]),
+        euclidean_basis=ImmutableDenseMatrix([x]),
+        axes=(x,),
+        order=1,
+    )
+
+    assert basis.rep == ImmutableDenseMatrix([-1])
+    assert basis.expr == -x
+
+
 def test_affine_group_full_rep_kronecker_power():
     x, y = sy.symbols("x y")
     _, offset = _space_and_offset(2)

--- a/tests/test_pointgroup_ops.py
+++ b/tests/test_pointgroup_ops.py
@@ -12,6 +12,7 @@ from qten.pointgroups.abelian import (
 )
 from qten.pointgroups.ops import (
     abelian_column_symmetrize,
+    get_direct_transform,
     joint_abelian_basis,
     joint_abelian_column_symmetrize,
 )
@@ -270,6 +271,58 @@ def test_joint_abelian_basis_returns_common_diagonal_mirror_eigenfunctions():
     assert {
         sy.expand(bases[0].expr) for bases in common.values() if len(bases) == 1
     } == {x + y, x - y}
+
+
+def test_get_direct_transform_builds_transformed_output_space_for_affine_offsets():
+    x = sy.symbols("x")
+    space = AffineSpace(basis=ImmutableDenseMatrix.eye(1))
+    shift = _opr_with_offset(
+        irrep=ImmutableDenseMatrix([[1]]),
+        axes=(x,),
+        offset=Offset(rep=ImmutableDenseMatrix([1]), space=space),
+    )
+
+    src = HilbertSpace.new([_state(Offset(rep=ImmutableDenseMatrix([0]), space=space))])
+    transform = get_direct_transform(shift, src)
+
+    assert transform.dims[0] == src
+    assert isinstance(transform.dims[1], HilbertSpace)
+    assert transform.dims[1].elements() == (
+        _state(Offset(rep=ImmutableDenseMatrix([1]), space=space)),
+    )
+    assert torch.equal(
+        transform.data,
+        torch.tensor([[1.0 + 0.0j]], dtype=torch.complex128),
+    )
+
+
+def test_get_direct_transform_rotates_abelian_basis_directly_without_phase_in_data():
+    x, y = sy.symbols("x y")
+    space = AffineSpace(basis=ImmutableDenseMatrix.eye(2))
+    c4 = _opr_with_offset(
+        irrep=ImmutableDenseMatrix([[0, -1], [1, 0]]),
+        axes=(x, y),
+        offset=Offset(rep=ImmutableDenseMatrix([0, 0]), space=space),
+    )
+
+    fx = AbelianBasis(expr=x, axes=(x, y), order=1, rep=ImmutableDenseMatrix([1, 0]))
+    fy = AbelianBasis(expr=y, axes=(x, y), order=1, rep=ImmutableDenseMatrix([0, 1]))
+    src = HilbertSpace.new([_state(fx), _state(fy)])
+
+    transform = get_direct_transform(c4, src)
+    out_basis = transform.dims[1].elements()
+
+    assert out_basis[0].coef == sy.Integer(1)
+    assert out_basis[0].irrep_of(AbelianBasis).expr == y
+    assert out_basis[1].coef == sy.Integer(1)
+    assert out_basis[1].irrep_of(AbelianBasis).expr == -x
+    assert torch.equal(
+        transform.data,
+        torch.tensor(
+            [[1.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]],
+            dtype=torch.complex128,
+        ),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See #150

## Overview

This PR adds a direct point-group transform helper for Hilbert-space bases and
updates abelian basis normalization so transformed polynomial bases preserve the
sign or phase of the leading non-zero term.

## What Changed

- Added `get_direct_transform()` in `qten.pointgroups.ops` to build explicit
  basis-mapping tensors from an input `HilbertSpace` to its transformed output
  space.
- Exported `get_direct_transform()` through `qten.pointgroups` and top-level
  `qten.ops`.
- Added direct transformation support for `AbelianBasis` irreps in external
  basis mappings without pushing the phase into tensor data.
- Updated `AbelianBasis.from_rep()` to normalize by the magnitude of the first
  non-zero coefficient, preserving its sign or complex phase.

## Why

The new helper supports point-group actions that do not preserve the original
ray structure of the input Hilbert space. Instead of forcing those operations
through a phase-based representation tensor, it constructs the transformed
output basis explicitly and returns the corresponding one-hot mapping matrix.

## Tests

- Added coverage for `AbelianBasis.from_rep()` normalization behavior.
- Added coverage for direct transforms that shift affine offsets into a new
  output space.
- Added coverage for direct transforms of rotated `AbelianBasis` functions,
  verifying that the basis labels change while the tensor data remains a direct
  mapping.
