### PR TITLE
Add optional `wrap_fractional` to `interpolate_path` for unfolded k-paths

### DIFF
--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -132,8 +132,7 @@ def interpolate_path(
         They are rebased to `recip` before interpolation.
     wrap_fractional : bool, default=True
         If True, wrap each rebased waypoint into the canonical fractional cell
-        before interpolation. Set to False to preserve raw rebased coordinates
-        (useful for unfolded path visualization/debugging).
+        before interpolation. Set to False to preserve raw rebased coordinates.
     Returns
     -------
     BzPath

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -114,6 +114,7 @@ def interpolate_path(
     waypoints: Sequence[str],
     points: KPointSet,
     n_points: int = 100,
+    wrap_fractional: bool = True,
 ) -> BzPath:
     """
     Build a sampled Brillouin-zone path in a reciprocal lattice.
@@ -129,6 +130,10 @@ def interpolate_path(
     points : KPointSet
         Named reciprocal-space points carrying their source reciprocal lattice.
         They are rebased to `recip` before interpolation.
+    wrap_fractional : bool, default=True
+        If True, wrap each rebased waypoint into the canonical fractional cell
+        before interpolation. Set to False to preserve raw rebased coordinates
+        (useful for unfolded path visualization/debugging).
     Returns
     -------
     BzPath
@@ -180,7 +185,8 @@ def interpolate_path(
                 f"the points dictionary. Available names: "
                 f"{sorted(rebased_points.points.keys()) if rebased_points.points else '(empty)'}."
             )
-        resolved_wp.append(rebased_points.points[wp].fractional())
+        rebased_wp = rebased_points.points[wp]
+        resolved_wp.append(rebased_wp.fractional() if wrap_fractional else rebased_wp)
 
     if n_points < len(resolved_wp):
         raise ValueError(

--- a/tests/test_bands.py
+++ b/tests/test_bands.py
@@ -744,6 +744,31 @@ def test_interpolate_path_wraps_rebased_waypoints_to_fractional_cell():
     assert end_k.rep == ImmutableDenseMatrix([sy.Rational(1, 2), sy.Rational(3, 4)])
 
 
+def test_interpolate_path_can_preserve_unwrapped_rebased_waypoints():
+    recip = _recip_2d()
+    kpoints = KPointSet.from_points(
+        recip,
+        {
+            "G": (0, 0),
+            "X": (sy.Rational(3, 2), sy.Rational(-1, 4)),
+        },
+    )
+
+    waypoints = ["G", "X"]
+    path = interpolate_path(
+        recip,
+        waypoints,
+        kpoints,
+        n_points=8,
+        wrap_fractional=False,
+    )
+    elements = path.k_space.elements()
+    end_k = elements[path.path_order[path.waypoint_indices[1]]]
+
+    assert end_k == kpoints.points["X"].rebase(recip)
+    assert end_k.rep == ImmutableDenseMatrix([sy.Rational(3, 2), sy.Rational(-1, 4)])
+
+
 def test_interpolate_path_accessible_via_ops():
     from qten.bands import interpolate_path as ip
 


### PR DESCRIPTION
## Summary
- Adds a new optional argument `wrap_fractional: bool = True` to `qten.bands.interpolate_path`.
- Preserves current behavior by default (`wrap_fractional=True`), where rebased waypoints are wrapped into the canonical fractional cell.
- Enables unfolded path construction with `wrap_fractional=False`, so rebased waypoint coordinates are kept as-is (no modulo-cell wrapping), which helps when plotting paths that should follow the original label sequence without collapsing equivalent points.

## Why
When interpolating a path in a target reciprocal lattice different from the source `KPointSet` lattice, canonical fractional wrapping can cause distinct labeled waypoints to map onto the same folded point. This makes path ticks/labels appear merged in bandstructure plots.  
This PR makes that wrapping behavior configurable without breaking existing callers.

## API Change
- `interpolate_path(recip, waypoints, points, n_points=100, wrap_fractional=True) -> BzPath`

Behavior:
- `wrap_fractional=True` (default): uses `rebased_wp.fractional()` (existing behavior)
- `wrap_fractional=False`: uses raw `rebased_wp` coordinates

## Tests
- Existing interpolation/path tests remain passing.
- Added test:
  - `test_interpolate_path_can_preserve_unwrapped_rebased_waypoints`
  - Verifies that with `wrap_fractional=False`, an endpoint like `(3/2, -1/4)` is preserved instead of wrapped to `(1/2, 3/4)`.

## Validation
- `uv run pytest "tests/test_bands.py" -k "interpolate_path"` passed
- `uv run pytest "tests/test_plots.py" -k "bandstructure and bz_path"` passed

## Example Usage
```python
path = Q.interpolate_path(
    blocked_diamond.dual,
    ["Gamma", "L", "U", "X", "W", "L", "K", "Gamma", "U", "W", "Gamma", "X"],
    points=kpts,
    n_points=500,
    wrap_fractional=False,
)
```