### PR TITLE
Fix `qten.eye` dims preservation for batched identities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qten"
-version = "0.4.2"
+version = "0.4.3"
 description = "Torch-based tensors, lattices, symmetries, and band-structure tools for quantum lattice models."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/qten/linalg/tensors.py
+++ b/src/qten/linalg/tensors.py
@@ -4768,11 +4768,11 @@ def mapping_matrix(
 
 def eye(dims: Tuple[StateSpace, ...], *, device: Optional[Device] = None) -> Tensor:
     """
-    Create an identity matrix tensor from the last two symbolic dimensions.
+    Create an identity tensor on the requested symbolic dimensions.
 
-    This helper interprets `dims[-2:]` as the matrix axes and returns a rank-2
-    identity tensor on those spaces. Any leading dimensions in `dims` are
-    ignored; this function does not build a batched identity tensor.
+    This helper interprets `dims[-2:]` as the matrix axes. When leading
+    dimensions are present, it broadcasts the identity across those axes so the
+    returned tensor preserves the full `dims` tuple.
 
     Parameters
     ----------
@@ -4785,7 +4785,7 @@ def eye(dims: Tuple[StateSpace, ...], *, device: Optional[Device] = None) -> Ten
     Returns
     -------
     Tensor
-        Rank-2 identity tensor with dims `(dims[-2], dims[-1])`.
+        Identity tensor with dims equal to `dims`.
 
     Raises
     ------
@@ -4796,11 +4796,16 @@ def eye(dims: Tuple[StateSpace, ...], *, device: Optional[Device] = None) -> Ten
         raise ValueError(
             f"Identity tensor creation requires at least rank 2, got rank {len(dims)}!"
         )
-    matrix_dims = dims[-2:]
-    rows = matrix_dims[0].dim
-    cols = matrix_dims[1].dim
+    rows = dims[-2].dim
+    cols = dims[-1].dim
+    leading_shape = tuple(dim.dim for dim in dims[:-2])
     torch_device = device.torch_device() if device is not None else None
-    return Tensor(data=torch.eye(rows, cols, device=torch_device), dims=matrix_dims)
+    data = torch.eye(rows, cols, device=torch_device)
+    if leading_shape:
+        data = data.reshape((1,) * len(leading_shape) + (rows, cols)).expand(
+            leading_shape + (rows, cols)
+        )
+    return Tensor(data=data, dims=dims)
 
 
 def zeros(dims: Tuple[StateSpace, ...], *, device: Optional[Device] = None) -> Tensor:

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -13,6 +13,7 @@ from qten.linalg.tensors import (
     allclose,
     astype,
     cat,
+    eye,
     einsum,
     equal,
     imag as tensor_imag,
@@ -1003,6 +1004,16 @@ class TestTensorOperations:
         assert out.dims == dims
         assert out.data.shape == (2, 2)
         assert torch.equal(out.data, torch.ones(2, 2))
+
+    def test_eye_helper_preserves_full_dims(self, tensor_ops_ctx):
+        dims = (tensor_ops_ctx.space_a, tensor_ops_ctx.space_a, tensor_ops_ctx.space_a)
+        out = eye(dims)
+        expected = torch.eye(2).expand(2, 2, 2)
+
+        assert isinstance(out, Tensor)
+        assert out.dims == dims
+        assert out.data.shape == (2, 2, 2)
+        assert torch.equal(out.data, expected)
 
     def test_neg(self, tensor_ops_ctx):
         res = -tensor_ops_ctx.tensor


### PR DESCRIPTION
See #177

## Descriptions
Preserve the full input dims tuple in qten.eye instead of dropping leading axes and returning only dims[-2:].

When leading dimensions are present, build the matrix identity on the last two axes and broadcast it across the leading axes so the returned tensor keeps the original symbolic layout. This restores the expected behavior that:
```python
I = qten.eye(dims)
I.dims == dims
```
Add a regression test covering the higher-rank case to ensure both dims and broadcasted identity data are preserved.