### PR TITLE
Add `diagonal` and `diag_embed` methods to `Tensor` class

### DIFF
--- a/src/qten/linalg/tensors.py
+++ b/src/qten/linalg/tensors.py
@@ -1092,6 +1092,28 @@ class Tensor(
         """
         return squeeze(self, dim)
 
+    def diagonal(self) -> Union[Self, "Tensor"]:
+        """
+        Extract the main diagonal of the last two matrix axes.
+
+        See Also
+        --------
+        [`diagonal(tensor)`][qten.linalg.tensors.diagonal]
+            Functional form with the full behavior description.
+        """
+        return diagonal(self)
+
+    def diag_embed(self) -> Union[Self, "Tensor"]:
+        """
+        Embed the last axis as the main diagonal of a square matrix.
+
+        See Also
+        --------
+        [`diag_embed(tensor)`][qten.linalg.tensors.diag_embed]
+            Functional form with the full behavior description.
+        """
+        return diag_embed(self)
+
     def index_add(
         self,
         dim: int,
@@ -3514,6 +3536,108 @@ def squeeze(tensor: TensorType, dim: int) -> Union[TensorType, Tensor]:
     new_data = tensor.data.squeeze(dim)
     new_dims = tensor.dims[:dim] + tensor.dims[dim + 1 :]
 
+    return cast(
+        TensorType,
+        _wrap_tensor_result(
+            tensor,
+            data=new_data,
+            dims=new_dims,
+            preserve_strict=False,
+        ),
+    )
+
+
+def diagonal(tensor: TensorType) -> Union[TensorType, Tensor]:
+    """
+    Extract the main diagonal over the last two matrix axes.
+
+    This is the metadata-aware analogue of
+    [`torch.diagonal`](https://docs.pytorch.org/docs/stable/generated/torch.diagonal.html)
+    with `dim1=-2` and `dim2=-1`. Leading axes are treated as batch dimensions
+    and are preserved. The last two axes must have the same size.
+
+    Parameters
+    ----------
+    tensor : Tensor
+        Input tensor of rank at least 2 whose last two axes form square
+        matrices.
+
+    Returns
+    -------
+    Union[TensorType, Tensor]
+        Tensor whose dims are `tensor.dims[:-2] + (tensor.dims[-2],)` and whose
+        data contain the main-diagonal entries of each matrix. For subclasses
+        marked with [`strict_dims`][qten.linalg.tensors.strict_dims], this may
+        return a plain [`Tensor`][qten.linalg.tensors.Tensor].
+
+    Raises
+    ------
+    ValueError
+        If `tensor` has rank less than 2, or if the last two axes have different
+        sizes.
+    """
+    if tensor.rank() < 2:
+        raise ValueError(
+            f"diagonal requires at least rank 2, got rank {tensor.rank()}"
+        )
+    row_dim, col_dim = tensor.dims[-2], tensor.dims[-1]
+    if row_dim.dim != col_dim.dim:
+        raise ValueError(
+            "diagonal requires the last two dimensions to have the same size, "
+            f"got {row_dim.dim} and {col_dim.dim}"
+        )
+
+    new_data = torch.diagonal(tensor.data, offset=0, dim1=-2, dim2=-1)
+    new_dims = tensor.dims[:-2] + (row_dim,)
+    return cast(
+        TensorType,
+        _wrap_tensor_result(
+            tensor,
+            data=new_data,
+            dims=new_dims,
+            preserve_strict=False,
+        ),
+    )
+
+
+def diag_embed(tensor: TensorType) -> Union[TensorType, Tensor]:
+    """
+    Embed the last axis as the main diagonal of a square matrix.
+
+    This is the metadata-aware analogue of
+    [`torch.diag_embed`](https://docs.pytorch.org/docs/stable/generated/torch.diag_embed.html).
+    Leading axes are treated as batch dimensions and are preserved. The last
+    [`StateSpace`][qten.symbolics.state_space.StateSpace] is duplicated to form
+    the new row and column axes.
+
+    Parameters
+    ----------
+    tensor : Tensor
+        Input tensor of rank at least 1 whose last axis supplies the diagonal
+        entries.
+
+    Returns
+    -------
+    Union[TensorType, Tensor]
+        Tensor whose dims are
+        `tensor.dims[:-1] + (tensor.dims[-1], tensor.dims[-1])` and whose data
+        place the input values on the main diagonal. For subclasses marked with
+        [`strict_dims`][qten.linalg.tensors.strict_dims], this may return a
+        plain [`Tensor`][qten.linalg.tensors.Tensor].
+
+    Raises
+    ------
+    ValueError
+        If `tensor` has rank less than 1.
+    """
+    if tensor.rank() < 1:
+        raise ValueError(
+            f"diag_embed requires at least rank 1, got rank {tensor.rank()}"
+        )
+
+    last_dim = tensor.dims[-1]
+    new_data = torch.diag_embed(tensor.data)
+    new_dims = tensor.dims[:-1] + (last_dim, last_dim)
     return cast(
         TensorType,
         _wrap_tensor_result(

--- a/src/qten/linalg/tensors.py
+++ b/src/qten/linalg/tensors.py
@@ -3577,9 +3577,7 @@ def diagonal(tensor: TensorType) -> Union[TensorType, Tensor]:
         sizes.
     """
     if tensor.rank() < 2:
-        raise ValueError(
-            f"diagonal requires at least rank 2, got rank {tensor.rank()}"
-        )
+        raise ValueError(f"diagonal requires at least rank 2, got rank {tensor.rank()}")
     row_dim, col_dim = tensor.dims[-2], tensor.dims[-1]
     if row_dim.dim != col_dim.dim:
         raise ValueError(

--- a/tests/test_tensors.py
+++ b/tests/test_tensors.py
@@ -13,6 +13,8 @@ from qten.linalg.tensors import (
     allclose,
     astype,
     cat,
+    diag_embed,
+    diagonal,
     eye,
     einsum,
     equal,
@@ -1014,6 +1016,61 @@ class TestTensorOperations:
         assert out.dims == dims
         assert out.data.shape == (2, 2, 2)
         assert torch.equal(out.data, expected)
+
+    def test_diagonal_extracts_main_diagonal(self, tensor_ops_ctx):
+        space = tensor_ops_ctx.space_a
+        data = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        t = Tensor(data=data, dims=(space, space))
+
+        out = t.diagonal()
+        assert out.dims == (space,)
+        assert torch.equal(out.data, torch.tensor([1.0, 4.0]))
+        assert torch.equal(diagonal(t).data, out.data)
+
+    def test_diagonal_preserves_batch_dims(self, tensor_ops_ctx):
+        space = tensor_ops_ctx.space_a
+        data = torch.arange(8, dtype=torch.float32).reshape(2, 2, 2)
+        t = Tensor(data=data, dims=(space, space, space))
+
+        out = t.diagonal()
+        assert out.dims == (space, space)
+        assert torch.equal(out.data, torch.diagonal(data, dim1=-2, dim2=-1))
+
+    def test_diagonal_rejects_nonsquare_last_axes(self, tensor_ops_ctx):
+        space_a = tensor_ops_ctx.space_a
+        space_b = _space_from_modes(make_mode("b", 3))
+        t = Tensor(data=torch.randn(2, 3), dims=(space_a, space_b))
+
+        with pytest.raises(ValueError, match="same size"):
+            t.diagonal()
+
+    def test_diagonal_rejects_rank_less_than_two(self, tensor_ops_ctx):
+        with pytest.raises(ValueError, match="at least rank 2"):
+            tensor_ops_ctx.tensor.diagonal()
+
+    def test_diag_embed_builds_diagonal_matrix(self, tensor_ops_ctx):
+        space = tensor_ops_ctx.space_a
+        data = torch.tensor([1.0, 2.0])
+        t = Tensor(data=data, dims=(space,))
+
+        out = t.diag_embed()
+        assert out.dims == (space, space)
+        assert torch.equal(out.data, torch.diag_embed(data))
+        assert torch.equal(diag_embed(t).data, out.data)
+
+    def test_diag_embed_preserves_batch_dims(self, tensor_ops_ctx):
+        space = tensor_ops_ctx.space_a
+        data = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+        t = Tensor(data=data, dims=(space, space))
+
+        out = t.diag_embed()
+        assert out.dims == (space, space, space)
+        assert torch.equal(out.data, torch.diag_embed(data))
+
+    def test_diag_embed_rejects_rank_zero(self):
+        scalar = Tensor.scalar(1.0)
+        with pytest.raises(ValueError, match="at least rank 1"):
+            scalar.diag_embed()
 
     def test_neg(self, tensor_ops_ctx):
         res = -tensor_ops_ctx.tensor


### PR DESCRIPTION
## Summary
- Add metadata-aware `diagonal` and `diag_embed` APIs on `Tensor` (methods + functional forms), mirroring `torch.diagonal` / `torch.diag_embed` while preserving `StateSpace` dims.
- `diagonal` extracts the main diagonal of the last two square axes; `diag_embed` embeds the last axis onto a square matrix diagonal; both keep leading batch dims.
- Add unit tests for happy paths, batch dims, and rejection of invalid ranks / non-square last axes.

## Branch
`dev/diag-tensor` → https://github.com/Alphaharrius/PyHilbert/pull/182

## Test plan
- [x] `pytest tests/test_tensors.py -k "diagonal or diag_embed"`
- [x] Confirm `t.diagonal()` / `diagonal(t)` and `t.diag_embed()` / `diag_embed(t)` agree on data
- [x] Confirm batch dims are preserved and invalid inputs raise the expected `ValueError`s