### PR TITLE
Added `upsample` and `cartesian_scale`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,9 @@ uv.lock
 
 # Notebooks
 *.ipynb
+
+# Images
+*.png
+*.jpg
+*.jpeg
+*.gif

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -85,7 +85,9 @@ from .symbolics import (
     StateSpace,
     U1Basis,
     brillouin_zone,
+    embedding_order,
     fractional_opr,
+    permutation_order,
     rebase_opr,
     restructure,
 )
@@ -2575,4 +2577,256 @@ def proj_wannierization(
         crystal_seeds,
         svd_threshold,
         infer_lattice=wannierize_lattice,
+    )
+
+
+def _momentum_preimage_indices(
+    src: MomentumSpace,
+    dest: MomentumSpace,
+    transform: Union[np.ndarray, Callable[[Momentum], Momentum]],
+    *,
+    device: Optional[Device] = None,
+) -> Tensor[torch.LongTensor]:
+    r"""
+    For each destination momentum, return one source index that maps onto it.
+
+    This is the dest-centric counterpart of
+    [`_momentum_match_indices`][qten.bands._momentum_match_indices]. Source
+    momenta are mapped into the destination fractional frame; the first source
+    (in `src` order) that lands on each destination sector is retained. Every
+    destination sector must have at least one preimage.
+    """
+    src_elements = src.elements()
+    dest_elements = dest.elements()
+    torch_device = device.torch_device() if device is not None else None
+    if not dest_elements:
+        return Tensor(
+            data=cast(
+                torch.LongTensor,
+                torch.tensor([], dtype=torch.long, device=torch_device),
+            ),
+            dims=(dest,),
+        )
+    if not src_elements:
+        raise ValueError(
+            "Source MomentumSpace is empty; cannot cover destination momenta."
+        )
+
+    if callable(transform):
+        recip_lat = src_elements[0].space
+        M, c, _ = _probe_affine(transform, recip_lat)
+    else:
+        M, c = transform, None
+
+    precision = get_precision_config()
+    src_frac = np.array(
+        [
+            [float(k.rep[j, 0]) for j in range(src_elements[0].space.dim)]
+            for k in src_elements
+        ],
+        dtype=precision.np_float,
+    )
+    mapped = src_frac @ M.T
+    if c is not None:
+        mapped = mapped + c
+    mapped_wrapped = mapped - np.floor(mapped)
+
+    first_dest_k = dest_elements[0]
+    dim = first_dest_k.space.dim
+    boundary_np = np.array(
+        first_dest_k.space.lattice.boundaries.basis.evalf(),
+        dtype=precision.np_float,
+    )
+    D = abs(int(round(np.linalg.det(boundary_np))))
+    mapped_scaled = np.rint(mapped_wrapped * D).astype(np.int64) % D
+    dest_coords = np.array(
+        [
+            [int(round(float(k.rep[j, 0]) * D)) % D for j in range(dim)]
+            for k in dest_elements
+        ],
+        dtype=np.int64,
+    )
+
+    first_src_for_coord: Dict[Tuple[int, ...], int] = {}
+    for src_i, coord in enumerate(mapped_scaled):
+        key = tuple(int(x) for x in coord)
+        if key not in first_src_for_coord:
+            first_src_for_coord[key] = src_i
+
+    indices = np.empty(len(dest_elements), dtype=np.int64)
+    for dest_i, coord in enumerate(dest_coords):
+        key = tuple(int(x) for x in coord)
+        if key not in first_src_for_coord:
+            raise ValueError(
+                f"Destination momentum at index {dest_i} with scaled coord "
+                f"{key} (D={D}) has no preimage in the source MomentumSpace."
+            )
+        indices[dest_i] = first_src_for_coord[key]
+
+    return Tensor(
+        data=cast(
+            torch.LongTensor,
+            torch.tensor(indices, dtype=torch.long, device=torch_device),
+        ),
+        dims=(dest,),
+    )
+
+
+def _downsample_gather_indices(
+    k_src: MomentumSpace,
+    k_target: MomentumSpace,
+    *,
+    device: Optional[Device] = None,
+) -> Tensor[torch.LongTensor]:
+    """Return source indices that cover each target momentum once."""
+    if k_src == k_target:
+        torch_device = device.torch_device() if device is not None else None
+        return Tensor(
+            data=cast(
+                torch.LongTensor,
+                torch.arange(k_src.dim, dtype=torch.long, device=torch_device),
+            ),
+            dims=(k_target,),
+        )
+
+    if k_src.same_rays(k_target) or (k_target in k_src):
+        if k_src.same_rays(k_target):
+            indices = permutation_order(k_src, k_target)
+        else:
+            indices = embedding_order(k_target, k_src)
+        torch_device = device.torch_device() if device is not None else None
+        return Tensor(
+            data=cast(
+                torch.LongTensor,
+                torch.tensor(indices, dtype=torch.long, device=torch_device),
+            ),
+            dims=(k_target,),
+        )
+
+    src_lattice_set = set(map(lambda k: k.space, k_src))
+    tgt_lattice_set = set(map(lambda k: k.space, k_target))
+    if len(src_lattice_set) != 1:
+        raise ValueError("Source MomentumSpace mixes incompatible reciprocal lattices")
+    if len(tgt_lattice_set) != 1:
+        raise ValueError("Target MomentumSpace mixes incompatible reciprocal lattices")
+
+    src_reciprocal = src_lattice_set.pop()
+    tgt_reciprocal = tgt_lattice_set.pop()
+    if not isinstance(src_reciprocal, ReciprocalLattice):
+        raise TypeError(
+            "Space of source momentum should be ReciprocalLattice, "
+            f"but got {type(src_reciprocal)}"
+        )
+    if not isinstance(tgt_reciprocal, ReciprocalLattice):
+        raise TypeError(
+            "Space of target momentum should be ReciprocalLattice, "
+            f"but got {type(tgt_reciprocal)}"
+        )
+
+    precision = get_precision_config()
+    src_basis_np = np.array(src_reciprocal.basis.evalf(), dtype=precision.np_float)
+    tgt_basis_np = np.array(tgt_reciprocal.basis.evalf(), dtype=precision.np_float)
+    M_rebase = np.linalg.solve(tgt_basis_np, src_basis_np)
+    return _momentum_preimage_indices(k_src, k_target, M_rebase, device=device)
+
+
+def downsampling(
+    T: Tensor,
+    k_target: MomentumSpace,
+) -> Tensor:
+    r"""
+    Restrict a momentum-resolved tensor onto a target Brillouin-zone grid.
+
+    The leading axis of the result is exactly `k_target`, so it can share a
+    [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace] with, for
+    example, the output of [`bandfold`][qten.bands.bandfold]. Hilbert-space
+    legs are left unchanged; this is the K-only counterpart of Brillouin-zone
+    folding.
+
+    Behavior
+    --------
+    When `k_target` is structurally contained in `T.dims[0]` (same momentum
+    labels, including permutations of the full set), this delegates to ordinary
+    tensor indexing and preserves exact symbolic identity of the selected
+    momenta.
+
+    Otherwise the source and target reciprocal lattices are related by the
+    Cartesian rebase
+    \(\kappa_{\mathrm{target}} = M\kappa_{\mathrm{source}}\pmod{1}\),
+    with \(M = B_{\mathrm{target}}^{-1} B_{\mathrm{source}}\). For each target
+    momentum, the first source sector (in source order) that maps onto it is
+    gathered. Coset partners that fold to the same target sector are discarded.
+
+    Parameters
+    ----------
+    T : Tensor
+        Momentum-resolved tensor whose first axis is a
+        [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace].
+    k_target : MomentumSpace
+        Target momentum grid. A common choice is `folded.dims[0]` after
+        [`bandfold`][qten.bands.bandfold].
+
+    Returns
+    -------
+    Tensor
+        dims `(k_target, *T.dims[1:])`.
+
+    Raises
+    ------
+    ValueError
+        If `T` has no axes, if either momentum space is empty or mixes
+        reciprocal lattices, or if some target momentum has no preimage in
+        `T.dims[0]`.
+    TypeError
+        If `T.dims[0]` or `k_target` is not a
+        [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace], or if a
+        momentum axis is not backed by a
+        [`ReciprocalLattice`][qten.geometries.spatials.ReciprocalLattice].
+
+    Examples
+    --------
+    Match the momentum grid of a folded band tensor:
+
+    ```python
+    folded = bandfold(transform, tensor)
+    sampled = downsampling(tensor, folded.dims[0])
+    assert sampled.dims[0] == folded.dims[0]
+    ```
+
+    See Also
+    --------
+    [`bandfold`][qten.bands.bandfold]
+        Fold momenta and enlarge Hilbert-space legs together (all cosets).
+    """
+    if T.rank() < 1:
+        raise ValueError("downsampling requires a tensor with at least one axis.")
+    if not isinstance(T.dims[0], MomentumSpace):
+        raise TypeError(
+            "The first dimension of the tensor must be a MomentumSpace, "
+            f"but is of type {type(T.dims[0])}"
+        )
+    if not isinstance(k_target, MomentumSpace):
+        raise TypeError(
+            f"k_target must be a MomentumSpace, but got {type(k_target)}"
+        )
+
+    k_src = cast(MomentumSpace, T.dims[0])
+    if not k_src.elements():
+        raise ValueError("Source MomentumSpace is empty")
+    if not k_target.elements():
+        raise ValueError("Target MomentumSpace is empty")
+
+    gather = _downsample_gather_indices(k_src, k_target, device=T.device)
+
+    if k_src == k_target:
+        return T
+
+    # Same symbolic momentum labels: reuse StateSpace-aware indexing.
+    if k_src.same_rays(k_target) or (k_target in k_src):
+        index = (k_target,) + (slice(None),) * (T.rank() - 1)
+        return cast(Tensor, T[index])
+
+    return Tensor(
+        data=T.data[gather.data],
+        dims=(k_target, *T.dims[1:]),
     )

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -37,13 +37,12 @@ symbolic state spaces label tensor axes, and linear algebra routines diagonalize
 the momentum-sector matrices when filling or selecting bands.
 """
 
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 import math
 from typing import (
     Any,
     Callable,
     Dict,
-    List,
     Literal,
     Optional,
     Sequence,
@@ -88,9 +87,7 @@ from .symbolics import (
     StateSpace,
     U1Basis,
     brillouin_zone,
-    embedding_order,
     fractional_opr,
-    permutation_order,
     rebase_opr,
     restructure,
 )
@@ -2817,350 +2814,105 @@ def proj_wannierization(
     )
 
 
-def _momentum_all_preimages(
-    src: MomentumSpace,
-    dest: MomentumSpace,
-    transform: Union[np.ndarray, Callable[[Momentum], Momentum]],
-) -> List[List[int]]:
+def cartesian_scale(tensor: Tensor, scale: Sequence[sy.Expr | int]) -> Tensor:
     r"""
-    For each destination momentum, return all source indices that map onto it.
+    Rescale the Cartesian geometry of a momentum-resolved tensor in place of
+    selecting or interpolating its information.
 
-    Source momenta are mapped into the destination fractional frame. Every
-    destination sector must have at least one preimage. Within each destination
-    bucket, source indices appear in `src` order.
-    """
-    src_elements = src.elements()
-    dest_elements = dest.elements()
-    if not dest_elements:
-        return []
-    if not src_elements:
-        raise ValueError(
-            "Source MomentumSpace is empty; cannot cover destination momenta."
-        )
-
-    if callable(transform):
-        recip_lat = src_elements[0].space
-        M, c, _ = _probe_affine(transform, recip_lat)
-    else:
-        M, c = transform, None
-
-    precision = get_precision_config()
-    src_frac = np.array(
-        [
-            [float(k.rep[j, 0]) for j in range(src_elements[0].space.dim)]
-            for k in src_elements
-        ],
-        dtype=precision.np_float,
-    )
-    mapped = src_frac @ M.T
-    if c is not None:
-        mapped = mapped + c
-    mapped_wrapped = mapped - np.floor(mapped)
-
-    first_dest_k = dest_elements[0]
-    dim = first_dest_k.space.dim
-    boundary_np = np.array(
-        first_dest_k.space.lattice.boundaries.basis.evalf(),
-        dtype=precision.np_float,
-    )
-    D = abs(int(round(np.linalg.det(boundary_np))))
-    mapped_scaled = np.rint(mapped_wrapped * D).astype(np.int64) % D
-    dest_coords = np.array(
-        [
-            [int(round(float(k.rep[j, 0]) * D)) % D for j in range(dim)]
-            for k in dest_elements
-        ],
-        dtype=np.int64,
-    )
-
-    src_for_coord: Dict[Tuple[int, ...], List[int]] = defaultdict(list)
-    for src_i, coord in enumerate(mapped_scaled):
-        key = tuple(int(x) for x in coord)
-        src_for_coord[key].append(src_i)
-
-    all_preimages: List[List[int]] = []
-    for dest_i, coord in enumerate(dest_coords):
-        key = tuple(int(x) for x in coord)
-        bucket = src_for_coord.get(key)
-        if not bucket:
-            raise ValueError(
-                f"Destination momentum at index {dest_i} with scaled coord "
-                f"{key} (D={D}) has no preimage in the source MomentumSpace."
-            )
-        all_preimages.append(bucket)
-    return all_preimages
-
-
-def _momentum_preimage_indices(
-    src: MomentumSpace,
-    dest: MomentumSpace,
-    transform: Union[np.ndarray, Callable[[Momentum], Momentum]],
-    *,
-    device: Optional[Device] = None,
-    choose: Optional[Callable[[int, Sequence[int]], int]] = None,
-) -> Tensor[torch.LongTensor]:
-    r"""
-    For each destination momentum, return one source index that maps onto it.
-
-    This is the dest-centric counterpart of
-    [`_momentum_match_indices`][qten.bands._momentum_match_indices]. By default
-    the first source (in `src` order) is retained. Pass `choose(dest_i,
-    src_indices)` to select among coset partners.
-    """
-    torch_device = device.torch_device() if device is not None else None
-    dest_elements = dest.elements()
-    if not dest_elements:
-        return Tensor(
-            data=cast(
-                torch.LongTensor,
-                torch.tensor([], dtype=torch.long, device=torch_device),
-            ),
-            dims=(dest,),
-        )
-
-    all_preimages = _momentum_all_preimages(src, dest, transform)
-    if choose is None:
-        indices = np.array([bucket[0] for bucket in all_preimages], dtype=np.int64)
-    else:
-        indices = np.empty(len(all_preimages), dtype=np.int64)
-        for dest_i, bucket in enumerate(all_preimages):
-            indices[dest_i] = int(choose(dest_i, bucket))
-
-    return Tensor(
-        data=cast(
-            torch.LongTensor,
-            torch.tensor(indices, dtype=torch.long, device=torch_device),
-        ),
-        dims=(dest,),
-    )
-
-
-def _spectral_touching_score(block: torch.Tensor) -> float:
-    """Return the smallest adjacent eigenvalue gap of a Hermitian block."""
-    herm = 0.5 * (block + block.mH)
-    evals = torch.linalg.eigvalsh(herm)
-    if evals.numel() == 0:
-        return float("inf")
-    if evals.numel() == 1:
-        return float(evals.abs().item())
-    return float((evals[1:] - evals[:-1]).min().item())
-
-
-def _choose_gap_preimage(
-    data: torch.Tensor,
-    dest_i: int,
-    src_indices: Sequence[int],
-) -> int:
-    """Pick the coset partner whose matrix block is closest to a band touching."""
-    del dest_i
-    best_src = int(src_indices[0])
-    best_score = float("inf")
-    for src_i in src_indices:
-        score = _spectral_touching_score(data[int(src_i)])
-        if score < best_score:
-            best_score = score
-            best_src = int(src_i)
-    return best_src
-
-
-def _downsample_gather_indices(
-    k_src: MomentumSpace,
-    k_target: MomentumSpace,
-    *,
-    device: Optional[Device] = None,
-    choose: Optional[Callable[[int, Sequence[int]], int]] = None,
-) -> Tensor[torch.LongTensor]:
-    """Return source indices that cover each target momentum once."""
-    if k_src == k_target:
-        torch_device = device.torch_device() if device is not None else None
-        return Tensor(
-            data=cast(
-                torch.LongTensor,
-                torch.arange(k_src.dim, dtype=torch.long, device=torch_device),
-            ),
-            dims=(k_target,),
-        )
-
-    if k_src.same_rays(k_target) or (k_target in k_src):
-        # Unique embedding / permutation: coset selection does not apply.
-        if k_src.same_rays(k_target):
-            indices = permutation_order(k_src, k_target)
-        else:
-            indices = embedding_order(k_target, k_src)
-        torch_device = device.torch_device() if device is not None else None
-        return Tensor(
-            data=cast(
-                torch.LongTensor,
-                torch.tensor(indices, dtype=torch.long, device=torch_device),
-            ),
-            dims=(k_target,),
-        )
-
-    src_lattice_set = set(map(lambda k: k.space, k_src))
-    tgt_lattice_set = set(map(lambda k: k.space, k_target))
-    if len(src_lattice_set) != 1:
-        raise ValueError("Source MomentumSpace mixes incompatible reciprocal lattices")
-    if len(tgt_lattice_set) != 1:
-        raise ValueError("Target MomentumSpace mixes incompatible reciprocal lattices")
-
-    src_reciprocal = src_lattice_set.pop()
-    tgt_reciprocal = tgt_lattice_set.pop()
-    if not isinstance(src_reciprocal, ReciprocalLattice):
-        raise TypeError(
-            "Space of source momentum should be ReciprocalLattice, "
-            f"but got {type(src_reciprocal)}"
-        )
-    if not isinstance(tgt_reciprocal, ReciprocalLattice):
-        raise TypeError(
-            "Space of target momentum should be ReciprocalLattice, "
-            f"but got {type(tgt_reciprocal)}"
-        )
-
-    precision = get_precision_config()
-    src_basis_np = np.array(src_reciprocal.basis.evalf(), dtype=precision.np_float)
-    tgt_basis_np = np.array(tgt_reciprocal.basis.evalf(), dtype=precision.np_float)
-    M_rebase = np.linalg.solve(tgt_basis_np, src_basis_np)
-    return _momentum_preimage_indices(
-        k_src, k_target, M_rebase, device=device, choose=choose
-    )
-
-
-def downsampling(
-    T: Tensor,
-    k_target: MomentumSpace,
-    *,
-    preimage: Literal["first", "gap"] = "first",
-) -> Tensor:
-    r"""
-    Restrict a momentum-resolved tensor onto a target Brillouin-zone grid.
-
-    The leading axis of the result is exactly `k_target`, so it can share a
-    [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace] with, for
-    example, the output of [`bandfold`][qten.bands.bandfold]. Hilbert-space
-    legs are left unchanged; this is the K-only counterpart of Brillouin-zone
-    folding.
-
-    Behavior
-    --------
-    When `k_target` is structurally contained in `T.dims[0]` (same momentum
-    labels, including permutations of the full set), this delegates to ordinary
-    tensor indexing and preserves exact symbolic identity of the selected
-    momenta.
-
-    Otherwise the source and target reciprocal lattices are related by the
-    Cartesian rebase
-    \(\kappa_{\mathrm{target}} = M\kappa_{\mathrm{source}}\pmod{1}\),
-    with \(M = B_{\mathrm{target}}^{-1} B_{\mathrm{source}}\). Several source
-    momenta (coset partners / umklapp images) can map to the same target
-    sector; `preimage` chooses which one is kept.
-
-    This choice is what goes wrong for honeycomb Dirac cones under naive
-    downsampling: \(K\) and \(K'\) fold to *different* reduced-zone points, but
-    each of those points also has mundane coset partners. Keeping only the
-    first partner in source order typically preserves one valley and replaces
-    the other by a gapped preimage — one cone "flies away". That routing is a
-    **k-space coset choice**, not a Hilbert-space Clifford / Fourier
-    \(\gamma\)-matrix. Orbital phase matrices from
-    [`get_band_fold`][qten.bands.get_band_fold] do not move eigenvalues.
+    For Cartesian scale matrix \(S=\operatorname{diag}(s_1,\ldots,s_d)\), a
+    direct-lattice basis \(A\) becomes \(SA\). Its reciprocal basis therefore
+    becomes \(S^{-T}G\). Fractional real-space and momentum coordinates,
+    periodic boundaries, unit-cell sites, tensor data, and every axis size are
+    preserved.
 
     Parameters
     ----------
-    T : Tensor
+    tensor : Tensor
         Momentum-resolved tensor whose first axis is a
         [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace].
-    k_target : MomentumSpace
-        Target momentum grid. A common choice is `folded.dims[0]` after
-        [`bandfold`][qten.bands.bandfold].
-    preimage : {"first", "gap"}, default="first"
-        Coset-selection policy when lattices differ:
-
-        - `"first"`: keep the first source sector in source order (legacy).
-        - `"gap"`: among partners of each target \(k'\), keep the block whose
-          Hermitian spectrum is closest to a band touching (smallest adjacent
-          eigenvalue gap). This is lattice-agnostic and recovers both honeycomb
-          valleys without special-casing \(K/K'\`. Requires a rank-3 tensor with
-          square matrix legs.
+    scale : Sequence[sympy.Expr | int | float]
+        Nonzero Cartesian scale factor for each spatial direction. Entries
+        must be Python integers or symbolic SymPy expressions.
 
     Returns
     -------
     Tensor
-        dims `(k_target, *T.dims[1:])`.
+        A tensor sharing the original data with geometrically rescaled
+        `MomentumSpace` and spatial `HilbertSpace` dimensions.
 
     Raises
     ------
     ValueError
-        If `T` has no axes, if either momentum space is empty or mixes
-        reciprocal lattices, if some target momentum has no preimage in
-        `T.dims[0]`, or if `preimage="gap"` is used with an incompatible tensor
-        shape.
+        If a scale entry is zero or its length differs from the spatial
+        dimension.
     TypeError
-        If `T.dims[0]` or `k_target` is not a
-        [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace], or if a
-        momentum axis is not backed by a
-        [`ReciprocalLattice`][qten.geometries.spatials.ReciprocalLattice].
-
-    Examples
-    --------
-    Match the momentum grid of a folded band tensor:
-
-    ```python
-    folded = bandfold(transform, tensor)
-    sampled = downsampling(tensor, folded.dims[0])
-    assert sampled.dims[0] == folded.dims[0]
-    ```
-
-    Keep Dirac touchings under honeycomb \(2\times 2\) blocking:
-
-    ```python
-    sampled = downsampling(bloch, folded.dims[0], preimage="gap")
-    ```
-
-    See Also
-    --------
-    [`bandfold`][qten.bands.bandfold]
-        Fold momenta and enlarge Hilbert-space legs together (all cosets).
+        If the first tensor dimension is not a `MomentumSpace`, a momentum is
+        not backed by a `ReciprocalLattice`, or a scale entry is neither an
+        integer nor a SymPy expression.
     """
-    if T.rank() < 1:
-        raise ValueError("downsampling requires a tensor with at least one axis.")
-    if not isinstance(T.dims[0], MomentumSpace):
+    if tensor.rank() < 1:
+        raise ValueError("cartesian_scale requires a tensor with at least one axis.")
+    if not isinstance(tensor.dims[0], MomentumSpace):
         raise TypeError(
             "The first dimension of the tensor must be a MomentumSpace, "
-            f"but is of type {type(T.dims[0])}"
+            f"but is of type {type(tensor.dims[0])}"
         )
-    if not isinstance(k_target, MomentumSpace):
-        raise TypeError(f"k_target must be a MomentumSpace, but got {type(k_target)}")
-    if preimage not in ("first", "gap"):
-        raise ValueError(f"preimage must be 'first' or 'gap', got {preimage!r}.")
 
-    k_src = cast(MomentumSpace, T.dims[0])
-    if not k_src.elements():
-        raise ValueError("Source MomentumSpace is empty")
-    if not k_target.elements():
-        raise ValueError("Target MomentumSpace is empty")
+    if any(
+        not isinstance(entry, sy.Expr)
+        and (not isinstance(entry, int) or isinstance(entry, bool))
+        for entry in scale
+    ):
+        raise TypeError("cartesian_scale scale entries must be int or sympy.Expr.")
+    factors = tuple(sy.sympify(entry) for entry in scale)
+    if any(sy.simplify(entry) == 0 for entry in factors):
+        raise ValueError("cartesian_scale scale entries must all be nonzero.")
 
-    choose_fn: Optional[Callable[[int, Sequence[int]], int]] = None
-    if preimage == "gap":
-        if T.rank() != 3 or T.data.shape[-1] != T.data.shape[-2]:
+    scaled_lattices: dict[Lattice, Lattice] = {}
+
+    def scale_lattice(lattice: Lattice) -> Lattice:
+        if len(factors) != lattice.dim:
             raise ValueError(
-                "preimage='gap' requires a rank-3 tensor with square matrix legs."
+                "cartesian_scale scale must have one entry per Cartesian direction: "
+                f"expected {lattice.dim}, got {len(factors)}."
             )
+        if lattice not in scaled_lattices:
+            scaled_lattices[lattice] = Lattice(
+                basis=ImmutableDenseMatrix.diag(*factors) @ lattice.basis,
+                boundaries=lattice.boundaries,
+                unit_cell={name: site.rep for name, site in lattice.unit_cell.items()},
+            )
+        return scaled_lattices[lattice]
 
-        def choose_fn(dest_i: int, src_indices: Sequence[int]) -> int:
-            return _choose_gap_preimage(T.data, dest_i, src_indices)
+    def scale_momentum(momentum: Momentum) -> Momentum:
+        if not isinstance(momentum.space, ReciprocalLattice):
+            raise TypeError(
+                "Momentum must be backed by a ReciprocalLattice, got "
+                f"{type(momentum.space).__name__}."
+            )
+        return Momentum(
+            rep=momentum.rep,
+            space=scale_lattice(momentum.space.dual).dual,
+        )
 
-    gather = _downsample_gather_indices(
-        k_src, k_target, device=T.device, choose=choose_fn
+    def scale_hilbert(space: HilbertSpace) -> HilbertSpace:
+        states: list[U1Basis] = []
+        for state in space.elements():
+            base = tuple(
+                Offset(rep=irrep.rep, space=scale_lattice(irrep.space))
+                if isinstance(irrep, Offset) and isinstance(irrep.space, Lattice)
+                else irrep
+                for irrep in state.base
+            )
+            states.append(U1Basis(coef=state.coef, base=base))
+        return HilbertSpace.new(states)
+
+    dims = tuple(
+        dim.map(scale_momentum)
+        if isinstance(dim, MomentumSpace)
+        else scale_hilbert(dim)
+        if isinstance(dim, HilbertSpace)
+        else dim
+        for dim in tensor.dims
     )
-
-    if k_src == k_target:
-        return T
-
-    # Same symbolic momentum labels: reuse StateSpace-aware indexing.
-    if choose_fn is None and (k_src.same_rays(k_target) or (k_target in k_src)):
-        index = (k_target,) + (slice(None),) * (T.rank() - 1)
-        return cast(Tensor, T[index])
-
-    return Tensor(
-        data=T.data[gather.data],
-        dims=(k_target, *T.dims[1:]),
-    )
+    return Tensor(data=tensor.data, dims=dims)

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -37,11 +37,12 @@ symbolic state spaces label tensor axes, and linear algebra routines diagonalize
 the momentum-sector matrices when filling or selecting bands.
 """
 
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from typing import (
     Any,
     Callable,
     Dict,
+    List,
     Literal,
     Optional,
     Sequence,
@@ -2580,33 +2581,22 @@ def proj_wannierization(
     )
 
 
-def _momentum_preimage_indices(
+def _momentum_all_preimages(
     src: MomentumSpace,
     dest: MomentumSpace,
     transform: Union[np.ndarray, Callable[[Momentum], Momentum]],
-    *,
-    device: Optional[Device] = None,
-) -> Tensor[torch.LongTensor]:
+) -> List[List[int]]:
     r"""
-    For each destination momentum, return one source index that maps onto it.
+    For each destination momentum, return all source indices that map onto it.
 
-    This is the dest-centric counterpart of
-    [`_momentum_match_indices`][qten.bands._momentum_match_indices]. Source
-    momenta are mapped into the destination fractional frame; the first source
-    (in `src` order) that lands on each destination sector is retained. Every
-    destination sector must have at least one preimage.
+    Source momenta are mapped into the destination fractional frame. Every
+    destination sector must have at least one preimage. Within each destination
+    bucket, source indices appear in `src` order.
     """
     src_elements = src.elements()
     dest_elements = dest.elements()
-    torch_device = device.torch_device() if device is not None else None
     if not dest_elements:
-        return Tensor(
-            data=cast(
-                torch.LongTensor,
-                torch.tensor([], dtype=torch.long, device=torch_device),
-            ),
-            dims=(dest,),
-        )
+        return []
     if not src_elements:
         raise ValueError(
             "Source MomentumSpace is empty; cannot cover destination momenta."
@@ -2647,21 +2637,58 @@ def _momentum_preimage_indices(
         dtype=np.int64,
     )
 
-    first_src_for_coord: Dict[Tuple[int, ...], int] = {}
+    src_for_coord: Dict[Tuple[int, ...], List[int]] = defaultdict(list)
     for src_i, coord in enumerate(mapped_scaled):
         key = tuple(int(x) for x in coord)
-        if key not in first_src_for_coord:
-            first_src_for_coord[key] = src_i
+        src_for_coord[key].append(src_i)
 
-    indices = np.empty(len(dest_elements), dtype=np.int64)
+    all_preimages: List[List[int]] = []
     for dest_i, coord in enumerate(dest_coords):
         key = tuple(int(x) for x in coord)
-        if key not in first_src_for_coord:
+        bucket = src_for_coord.get(key)
+        if not bucket:
             raise ValueError(
                 f"Destination momentum at index {dest_i} with scaled coord "
                 f"{key} (D={D}) has no preimage in the source MomentumSpace."
             )
-        indices[dest_i] = first_src_for_coord[key]
+        all_preimages.append(bucket)
+    return all_preimages
+
+
+def _momentum_preimage_indices(
+    src: MomentumSpace,
+    dest: MomentumSpace,
+    transform: Union[np.ndarray, Callable[[Momentum], Momentum]],
+    *,
+    device: Optional[Device] = None,
+    choose: Optional[Callable[[int, Sequence[int]], int]] = None,
+) -> Tensor[torch.LongTensor]:
+    r"""
+    For each destination momentum, return one source index that maps onto it.
+
+    This is the dest-centric counterpart of
+    [`_momentum_match_indices`][qten.bands._momentum_match_indices]. By default
+    the first source (in `src` order) is retained. Pass `choose(dest_i,
+    src_indices)` to select among coset partners.
+    """
+    torch_device = device.torch_device() if device is not None else None
+    dest_elements = dest.elements()
+    if not dest_elements:
+        return Tensor(
+            data=cast(
+                torch.LongTensor,
+                torch.tensor([], dtype=torch.long, device=torch_device),
+            ),
+            dims=(dest,),
+        )
+
+    all_preimages = _momentum_all_preimages(src, dest, transform)
+    if choose is None:
+        indices = np.array([bucket[0] for bucket in all_preimages], dtype=np.int64)
+    else:
+        indices = np.empty(len(all_preimages), dtype=np.int64)
+        for dest_i, bucket in enumerate(all_preimages):
+            indices[dest_i] = int(choose(dest_i, bucket))
 
     return Tensor(
         data=cast(
@@ -2672,11 +2699,40 @@ def _momentum_preimage_indices(
     )
 
 
+def _spectral_touching_score(block: torch.Tensor) -> float:
+    """Return the smallest adjacent eigenvalue gap of a Hermitian block."""
+    herm = 0.5 * (block + block.mH)
+    evals = torch.linalg.eigvalsh(herm)
+    if evals.numel() == 0:
+        return float("inf")
+    if evals.numel() == 1:
+        return float(evals.abs().item())
+    return float((evals[1:] - evals[:-1]).min().item())
+
+
+def _choose_gap_preimage(
+    data: torch.Tensor,
+    dest_i: int,
+    src_indices: Sequence[int],
+) -> int:
+    """Pick the coset partner whose matrix block is closest to a band touching."""
+    del dest_i
+    best_src = int(src_indices[0])
+    best_score = float("inf")
+    for src_i in src_indices:
+        score = _spectral_touching_score(data[int(src_i)])
+        if score < best_score:
+            best_score = score
+            best_src = int(src_i)
+    return best_src
+
+
 def _downsample_gather_indices(
     k_src: MomentumSpace,
     k_target: MomentumSpace,
     *,
     device: Optional[Device] = None,
+    choose: Optional[Callable[[int, Sequence[int]], int]] = None,
 ) -> Tensor[torch.LongTensor]:
     """Return source indices that cover each target momentum once."""
     if k_src == k_target:
@@ -2690,6 +2746,7 @@ def _downsample_gather_indices(
         )
 
     if k_src.same_rays(k_target) or (k_target in k_src):
+        # Unique embedding / permutation: coset selection does not apply.
         if k_src.same_rays(k_target):
             indices = permutation_order(k_src, k_target)
         else:
@@ -2727,12 +2784,16 @@ def _downsample_gather_indices(
     src_basis_np = np.array(src_reciprocal.basis.evalf(), dtype=precision.np_float)
     tgt_basis_np = np.array(tgt_reciprocal.basis.evalf(), dtype=precision.np_float)
     M_rebase = np.linalg.solve(tgt_basis_np, src_basis_np)
-    return _momentum_preimage_indices(k_src, k_target, M_rebase, device=device)
+    return _momentum_preimage_indices(
+        k_src, k_target, M_rebase, device=device, choose=choose
+    )
 
 
 def downsampling(
     T: Tensor,
     k_target: MomentumSpace,
+    *,
+    preimage: Literal["first", "gap"] = "first",
 ) -> Tensor:
     r"""
     Restrict a momentum-resolved tensor onto a target Brillouin-zone grid.
@@ -2753,9 +2814,18 @@ def downsampling(
     Otherwise the source and target reciprocal lattices are related by the
     Cartesian rebase
     \(\kappa_{\mathrm{target}} = M\kappa_{\mathrm{source}}\pmod{1}\),
-    with \(M = B_{\mathrm{target}}^{-1} B_{\mathrm{source}}\). For each target
-    momentum, the first source sector (in source order) that maps onto it is
-    gathered. Coset partners that fold to the same target sector are discarded.
+    with \(M = B_{\mathrm{target}}^{-1} B_{\mathrm{source}}\). Several source
+    momenta (coset partners / umklapp images) can map to the same target
+    sector; `preimage` chooses which one is kept.
+
+    This choice is what goes wrong for honeycomb Dirac cones under naive
+    downsampling: \(K\) and \(K'\) fold to *different* reduced-zone points, but
+    each of those points also has mundane coset partners. Keeping only the
+    first partner in source order typically preserves one valley and replaces
+    the other by a gapped preimage — one cone "flies away". That routing is a
+    **k-space coset choice**, not a Hilbert-space Clifford / Fourier
+    \(\gamma\)-matrix. Orbital phase matrices from
+    [`get_band_fold`][qten.bands.get_band_fold] do not move eigenvalues.
 
     Parameters
     ----------
@@ -2765,6 +2835,15 @@ def downsampling(
     k_target : MomentumSpace
         Target momentum grid. A common choice is `folded.dims[0]` after
         [`bandfold`][qten.bands.bandfold].
+    preimage : {"first", "gap"}, default="first"
+        Coset-selection policy when lattices differ:
+
+        - `"first"`: keep the first source sector in source order (legacy).
+        - `"gap"`: among partners of each target \(k'\), keep the block whose
+          Hermitian spectrum is closest to a band touching (smallest adjacent
+          eigenvalue gap). This is lattice-agnostic and recovers both honeycomb
+          valleys without special-casing \(K/K'\`. Requires a rank-3 tensor with
+          square matrix legs.
 
     Returns
     -------
@@ -2775,8 +2854,9 @@ def downsampling(
     ------
     ValueError
         If `T` has no axes, if either momentum space is empty or mixes
-        reciprocal lattices, or if some target momentum has no preimage in
-        `T.dims[0]`.
+        reciprocal lattices, if some target momentum has no preimage in
+        `T.dims[0]`, or if `preimage="gap"` is used with an incompatible tensor
+        shape.
     TypeError
         If `T.dims[0]` or `k_target` is not a
         [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace], or if a
@@ -2793,6 +2873,12 @@ def downsampling(
     assert sampled.dims[0] == folded.dims[0]
     ```
 
+    Keep Dirac touchings under honeycomb \(2\times 2\) blocking:
+
+    ```python
+    sampled = downsampling(bloch, folded.dims[0], preimage="gap")
+    ```
+
     See Also
     --------
     [`bandfold`][qten.bands.bandfold]
@@ -2807,6 +2893,10 @@ def downsampling(
         )
     if not isinstance(k_target, MomentumSpace):
         raise TypeError(f"k_target must be a MomentumSpace, but got {type(k_target)}")
+    if preimage not in ("first", "gap"):
+        raise ValueError(
+            f"preimage must be 'first' or 'gap', got {preimage!r}."
+        )
 
     k_src = cast(MomentumSpace, T.dims[0])
     if not k_src.elements():
@@ -2814,13 +2904,25 @@ def downsampling(
     if not k_target.elements():
         raise ValueError("Target MomentumSpace is empty")
 
-    gather = _downsample_gather_indices(k_src, k_target, device=T.device)
+    choose_fn: Optional[Callable[[int, Sequence[int]], int]] = None
+    if preimage == "gap":
+        if T.rank() != 3 or T.data.shape[-1] != T.data.shape[-2]:
+            raise ValueError(
+                "preimage='gap' requires a rank-3 tensor with square matrix legs."
+            )
+
+        def choose_fn(dest_i: int, src_indices: Sequence[int]) -> int:
+            return _choose_gap_preimage(T.data, dest_i, src_indices)
+
+    gather = _downsample_gather_indices(
+        k_src, k_target, device=T.device, choose=choose_fn
+    )
 
     if k_src == k_target:
         return T
 
     # Same symbolic momentum labels: reuse StateSpace-aware indexing.
-    if k_src.same_rays(k_target) or (k_target in k_src):
+    if choose_fn is None and (k_src.same_rays(k_target) or (k_target in k_src)):
         index = (k_target,) + (slice(None),) * (T.rank() - 1)
         return cast(Tensor, T[index])
 

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -62,6 +62,7 @@ from multimethod import multimethod
 import torch
 
 from .geometries import (
+    AffineSpace,
     BasisTransform,
     InverseBasisTransform,
     KPointSet,
@@ -226,15 +227,6 @@ def upsample(tensor: Tensor, scale: Tuple[int, ...]) -> Tensor:
         )
 
     boundary = lattice.boundaries.basis
-    boundary_inv = boundary.inv()
-    centered_reps: list[ImmutableDenseMatrix] = []
-    for rep in lattice.boundaries.representatives():
-        coeff = boundary_inv @ rep
-        shift = ImmutableDenseMatrix(
-            [sy.floor(coeff[i, 0] + sy.Rational(1, 2)) for i in range(dim)]
-        )
-        centered_reps.append(ImmutableDenseMatrix(rep - boundary @ shift))
-
     enlarged_boundary = ImmutableDenseMatrix(
         boundary @ ImmutableDenseMatrix.diag(*scale)
     )
@@ -284,6 +276,18 @@ def upsample(tensor: Tensor, scale: Tuple[int, ...]) -> Tensor:
             data=interpolated,
             dims=(new_k_space, left_space, right_space),
         )
+
+    # Only the dense cardinal kernel needs explicit centered translations.
+    # The rectangular FFT path above applies the same convention directly in
+    # integer index space.
+    boundary_inv = boundary.inv()
+    centered_reps: list[ImmutableDenseMatrix] = []
+    for rep in lattice.boundaries.representatives():
+        coeff = boundary_inv @ rep
+        shift = ImmutableDenseMatrix(
+            [sy.floor(coeff[i, 0] + sy.Rational(1, 2)) for i in range(dim)]
+        )
+        centered_reps.append(ImmutableDenseMatrix(rep - boundary @ shift))
 
     real_dtype = (
         torch.float32
@@ -2830,7 +2834,7 @@ def cartesian_scale(tensor: Tensor, scale: Sequence[sy.Expr | int]) -> Tensor:
     tensor : Tensor
         Momentum-resolved tensor whose first axis is a
         [`MomentumSpace`][qten.symbolics.state_space.MomentumSpace].
-    scale : Sequence[sympy.Expr | int | float]
+    scale : Sequence[sympy.Expr | int]
         Nonzero Cartesian scale factor for each spatial direction. Entries
         must be Python integers or symbolic SymPy expressions.
 
@@ -2868,21 +2872,28 @@ def cartesian_scale(tensor: Tensor, scale: Sequence[sy.Expr | int]) -> Tensor:
     if any(sy.simplify(entry) == 0 for entry in factors):
         raise ValueError("cartesian_scale scale entries must all be nonzero.")
 
-    scaled_lattices: dict[Lattice, Lattice] = {}
+    scaled_spaces: dict[AffineSpace, AffineSpace] = {}
 
-    def scale_lattice(lattice: Lattice) -> Lattice:
-        if len(factors) != lattice.dim:
+    def scale_space(space: AffineSpace) -> AffineSpace:
+        if len(factors) != space.dim:
             raise ValueError(
                 "cartesian_scale scale must have one entry per Cartesian direction: "
-                f"expected {lattice.dim}, got {len(factors)}."
+                f"expected {space.dim}, got {len(factors)}."
             )
-        if lattice not in scaled_lattices:
-            scaled_lattices[lattice] = Lattice(
-                basis=ImmutableDenseMatrix.diag(*factors) @ lattice.basis,
-                boundaries=lattice.boundaries,
-                unit_cell={name: site.rep for name, site in lattice.unit_cell.items()},
+        if space not in scaled_spaces:
+            basis = ImmutableDenseMatrix.diag(*factors) @ space.basis
+            scaled_spaces[space] = (
+                Lattice(
+                    basis=basis,
+                    boundaries=space.boundaries,
+                    unit_cell={
+                        name: site.rep for name, site in space.unit_cell.items()
+                    },
+                )
+                if isinstance(space, Lattice)
+                else AffineSpace(basis=basis)
             )
-        return scaled_lattices[lattice]
+        return scaled_spaces[space]
 
     def scale_momentum(momentum: Momentum) -> Momentum:
         if not isinstance(momentum.space, ReciprocalLattice):
@@ -2892,15 +2903,15 @@ def cartesian_scale(tensor: Tensor, scale: Sequence[sy.Expr | int]) -> Tensor:
             )
         return Momentum(
             rep=momentum.rep,
-            space=scale_lattice(momentum.space.dual).dual,
+            space=cast(Lattice, scale_space(momentum.space.dual)).dual,
         )
 
     def scale_hilbert(space: HilbertSpace) -> HilbertSpace:
         states: list[U1Basis] = []
         for state in space.elements():
             base = tuple(
-                Offset(rep=irrep.rep, space=scale_lattice(irrep.space))
-                if isinstance(irrep, Offset) and isinstance(irrep.space, Lattice)
+                Offset(rep=irrep.rep, space=scale_space(irrep.space))
+                if isinstance(irrep, Offset)
                 else irrep
                 for irrep in state.base
             )

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -38,6 +38,7 @@ the momentum-sector matrices when filling or selecting bands.
 """
 
 from collections import OrderedDict, defaultdict
+import math
 from typing import (
     Any,
     Callable,
@@ -68,6 +69,7 @@ from .geometries import (
     Lattice,
     Momentum,
     Offset,
+    PeriodicBoundary,
     ReciprocalLattice,
 )
 from .geometries.fourier import fourier_transform
@@ -95,6 +97,240 @@ from .symbolics import (
 from .pointgroups.elements import PointGroupOpr
 from .pointgroups.ops import _internal_transform_basis
 from .utils.devices import Device
+
+
+def _rectangular_upsample_data(
+    data: torch.Tensor,
+    shape: tuple[int, ...],
+    scale: tuple[int, ...],
+) -> torch.Tensor:
+    """Upsample a rectangular momentum grid without dense Fourier kernels.
+
+    This is the FFT equivalent of applying the real cardinal-weight matrix in
+    :func:`upsample`.  The two transforms are needed because taking the real
+    part of the cardinal kernel averages its positive- and negative-frequency
+    evaluations.  In particular, this preserves the established symmetric
+    treatment of even-grid Nyquist modes.
+    """
+    enlarged_shape = tuple(size * factor for size, factor in zip(shape, scale))
+    spatial_axes = tuple(range(len(shape)))
+    old_size = math.prod(shape)
+    new_size = math.prod(enlarged_shape)
+
+    # Move each raw FFT coefficient to the same *centered* translation in the
+    # enlarged cell.  For an even size, the half-period coefficient belongs to
+    # the negative representative, matching the dense implementation.
+    source_axes = [torch.arange(size, device=data.device) for size in shape]
+    source_grid = torch.meshgrid(*source_axes, indexing="ij")
+    target_indices = tuple(
+        torch.where(axis < (size + 1) // 2, axis, axis - size) % enlarged_size
+        for axis, size, enlarged_size in zip(source_grid, shape, enlarged_shape)
+    )
+
+    positive_coefficients = torch.fft.ifftn(data, dim=spatial_axes)
+    padded = positive_coefficients.new_zeros((*enlarged_shape, *data.shape[-2:]))
+    padded[target_indices] = positive_coefficients
+    interpolated = torch.fft.fftn(padded, dim=spatial_axes)
+
+    negative_coefficients = torch.fft.fftn(data, dim=spatial_axes) / old_size
+    padded = negative_coefficients.new_zeros((*enlarged_shape, *data.shape[-2:]))
+    padded[target_indices] = negative_coefficients
+    interpolated = (
+        interpolated + new_size * torch.fft.ifftn(padded, dim=spatial_axes)
+    ) / 2
+
+    if not data.is_complex():
+        return interpolated.real.to(data.dtype)
+    return interpolated
+
+
+def upsample(tensor: Tensor, scale: Tuple[int, ...]) -> Tensor:
+    r"""
+    Interpolate a momentum-resolved matrix tensor onto a denser BZ grid.
+
+    The interpolation is performed in the localized (Wannier) representation:
+    the sampled matrices are inverse Fourier transformed to hopping matrices on
+    the original finite real-space cell, then evaluated on the momentum grid
+    dual to an enlarged periodic cell.  Thus ``scale=(s1, ..., sd)`` multiplies
+    the real-space boundary generators by the corresponding positive integer
+    factors and increases the number of momentum sectors by ``prod(scale)``.
+
+    Centered representatives of the original translation quotient are used.
+    At an even-period boundary, the half-period translation is assigned to the
+    negative representative.  This convention is deterministic and generally
+    gives the locality-friendly interpolation used for Wannier Hamiltonians.
+
+    Parameters
+    ----------
+    tensor : Tensor
+        Matrix tensor with dims ``(MomentumSpace, HilbertSpace, HilbertSpace)``.
+        Its leading momentum space must be the complete Brillouin-zone grid of
+        a finite periodic lattice.
+    scale : Tuple[int, ...]
+        Positive integer enlargement factor for each real-space boundary
+        generator.
+
+    Returns
+    -------
+    Tensor
+        Interpolated tensor with dims ``(new_momentum_space, B_left, B_right)``.
+        Spatial Bloch spaces are relabeled onto the enlarged finite lattice
+        (whose primitive basis is unchanged), so subsequent operations such as
+        band folding see consistent lattice metadata. Complex input keeps its
+        dtype; real input is returned in its original real dtype.
+
+    Notes
+    -----
+    This is exact on the original momentum grid but does not create additional
+    physical information.  Reliable interpolation requires a consistent,
+    localized Bloch/orbital gauge; independently sorted eigenvalues are not a
+    substitute for the matrix-valued input.
+    """
+    if tensor.rank() != 3:
+        raise ValueError(
+            "upsample requires a rank-3 tensor with dims "
+            "(MomentumSpace, HilbertSpace, HilbertSpace)."
+        )
+    if not isinstance(tensor.dims[0], MomentumSpace):
+        raise TypeError("upsample requires the first dimension to be a MomentumSpace.")
+    if not isinstance(tensor.dims[1], HilbertSpace) or not isinstance(
+        tensor.dims[2], HilbertSpace
+    ):
+        raise TypeError("upsample requires both matrix dimensions to be HilbertSpace.")
+    if tensor.dims[1] != tensor.dims[2] or tensor.data.shape[1] != tensor.data.shape[2]:
+        raise ValueError("upsample requires equal, square Hilbert-space matrix legs.")
+
+    k_space = cast(MomentumSpace, tensor.dims[0])
+    if not k_space.elements():
+        raise ValueError("upsample requires a nonempty MomentumSpace.")
+    reciprocal = _wannier_reciprocal_lattice(k_space)
+    lattice = reciprocal.dual
+    dim = lattice.dim
+
+    if not isinstance(scale, tuple):
+        raise TypeError("upsample scale must be a tuple of positive integers.")
+    if len(scale) != dim:
+        raise ValueError(
+            f"upsample scale must have one entry per spatial dimension ({dim}), "
+            f"got {len(scale)}."
+        )
+    if any(isinstance(value, bool) or not isinstance(value, int) for value in scale):
+        raise TypeError("upsample scale entries must be positive integers (not bools).")
+    if any(value <= 0 for value in scale):
+        raise ValueError("upsample scale entries must all be positive.")
+
+    # The interpolation contract requires the complete character group, not an
+    # arbitrary path/subset that happens to use the same reciprocal lattice.
+    complete_k_space = brillouin_zone(reciprocal)
+    if k_space != complete_k_space:
+        raise ValueError(
+            "upsample requires the complete Brillouin-zone momentum grid in "
+            "its canonical order."
+        )
+
+    boundary = lattice.boundaries.basis
+    boundary_inv = boundary.inv()
+    centered_reps: list[ImmutableDenseMatrix] = []
+    for rep in lattice.boundaries.representatives():
+        coeff = boundary_inv @ rep
+        shift = ImmutableDenseMatrix(
+            [sy.floor(coeff[i, 0] + sy.Rational(1, 2)) for i in range(dim)]
+        )
+        centered_reps.append(ImmutableDenseMatrix(rep - boundary @ shift))
+
+    enlarged_boundary = ImmutableDenseMatrix(
+        boundary @ ImmutableDenseMatrix.diag(*scale)
+    )
+    enlarged_lattice = Lattice(
+        basis=lattice.basis,
+        boundaries=PeriodicBoundary(enlarged_boundary),
+        unit_cell={name: offset.rep for name, offset in lattice.unit_cell.items()},
+    )
+    new_k_space = brillouin_zone(enlarged_lattice.dual)
+
+    def _rehome_bloch_space(space: HilbertSpace) -> HilbertSpace:
+        """Relabel spatial states without changing their basis coordinates."""
+        states: list[U1Basis] = []
+        for element in space.elements():
+            state = cast(U1Basis, element)
+            try:
+                offset = state.irrep_of(Offset)
+            except ValueError:
+                # Abstract/non-spatial Hilbert spaces remain valid matrix labels.
+                return space
+            states.append(state.replace(offset.rebase(enlarged_lattice)))
+        return HilbertSpace.new(states)
+
+    left_space = _rehome_bloch_space(cast(HilbertSpace, tensor.dims[1]))
+    right_space = _rehome_bloch_space(cast(HilbertSpace, tensor.dims[2]))
+
+    # A diagonal positive boundary has the canonical Cartesian-product momentum
+    # order used by ``brillouin_zone``.  Exploit that separability with FFTs:
+    # memory is O(N_new * bands^2), rather than O(N_new * N_old), and runtime is
+    # O(N_new log N_new), rather than quadratic.  Keep the dense implementation
+    # below as the general fallback for skew periodic cells.
+    rectangular_shape: tuple[int, ...] | None = None
+    if boundary == ImmutableDenseMatrix.diag(
+        *(boundary[i, i] for i in range(dim))
+    ) and all(
+        bool(boundary[i, i].is_integer) and boundary[i, i] > 0 for i in range(dim)
+    ):
+        rectangular_shape = tuple(int(boundary[i, i]) for i in range(dim))
+
+    if rectangular_shape is not None:
+        matrix_shape = tuple(tensor.data.shape[1:])
+        grid_data = tensor.data.reshape(*rectangular_shape, *matrix_shape)
+        interpolated = _rectangular_upsample_data(
+            grid_data, rectangular_shape, scale
+        ).reshape(-1, *matrix_shape)
+        return Tensor(
+            data=interpolated,
+            dims=(new_k_space, left_space, right_space),
+        )
+
+    real_dtype = (
+        torch.float32
+        if tensor.data.dtype
+        in (torch.float16, torch.bfloat16, torch.float32, torch.complex64)
+        else torch.float64
+    )
+    complex_dtype = torch.complex64 if real_dtype == torch.float32 else torch.complex128
+    device = tensor.data.device
+    old_k = torch.tensor(
+        [[float(k.rep[i, 0]) for i in range(dim)] for k in k_space.elements()],
+        dtype=real_dtype,
+        device=device,
+    )
+    new_k = torch.tensor(
+        [[float(k.rep[i, 0]) for i in range(dim)] for k in new_k_space.elements()],
+        dtype=real_dtype,
+        device=device,
+    )
+    translations = torch.tensor(
+        [[float(rep[i, 0]) for i in range(dim)] for rep in centered_reps],
+        dtype=real_dtype,
+        device=device,
+    )
+    old_kernel = torch.exp(
+        (-2j * torch.pi * (old_k @ translations.T)).to(complex_dtype)
+    )
+    new_kernel = torch.exp(
+        (-2j * torch.pi * (new_k @ translations.T)).to(complex_dtype)
+    )
+
+    # The real part implements the symmetric ±R treatment of Nyquist modes.
+    # Without it, an even grid assigns a self-conjugate half-period mode to one
+    # sign only; complex interpolation coefficients then turn Hermitian input
+    # blocks non-Hermitian between samples.  Real cardinal weights interpolate
+    # every original block exactly while preserving conjugation relations.
+    weights = (new_kernel @ old_kernel.conj().T).real / k_space.dim
+    interpolated = torch.einsum(
+        "nk,kab->nab", weights.to(tensor.data.dtype), tensor.data
+    )
+    return Tensor(
+        data=interpolated,
+        dims=(new_k_space, left_space, right_space),
+    )
 
 
 def _basis_states_at_fractional_offset(
@@ -2894,9 +3130,7 @@ def downsampling(
     if not isinstance(k_target, MomentumSpace):
         raise TypeError(f"k_target must be a MomentumSpace, but got {type(k_target)}")
     if preimage not in ("first", "gap"):
-        raise ValueError(
-            f"preimage must be 'first' or 'gap', got {preimage!r}."
-        )
+        raise ValueError(f"preimage must be 'first' or 'gap', got {preimage!r}.")
 
     k_src = cast(MomentumSpace, T.dims[0])
     if not k_src.elements():

--- a/src/qten/bands.py
+++ b/src/qten/bands.py
@@ -2806,9 +2806,7 @@ def downsampling(
             f"but is of type {type(T.dims[0])}"
         )
     if not isinstance(k_target, MomentumSpace):
-        raise TypeError(
-            f"k_target must be a MomentumSpace, but got {type(k_target)}"
-        )
+        raise TypeError(f"k_target must be a MomentumSpace, but got {type(k_target)}")
 
     k_src = cast(MomentumSpace, T.dims[0])
     if not k_src.elements():

--- a/src/qten/ops.py
+++ b/src/qten/ops.py
@@ -21,6 +21,7 @@ Fourier and band operations
 - [`fourier_transform()`][qten.geometries.fourier.fourier_transform]
 - [`region_restrict()`][qten.geometries.fourier.region_restrict]
 - [`interpolate_path()`][qten.bands.interpolate_path]
+- [`upsample()`][qten.bands.upsample]
 - [`svd_projection()`][qten.bands.svd_projection]
 
 Symbolic operations
@@ -67,6 +68,7 @@ from .symbolics import (
 from .bands import (
     interpolate_path as interpolate_path,
     svd_projection as svd_projection,
+    upsample as upsample,
 )
 from .pointgroups.ops import (
     point_group_column_symmetrize as point_group_column_symmetrize,

--- a/tests/test_bands.py
+++ b/tests/test_bands.py
@@ -17,7 +17,10 @@ from qten.bands import (
     proj_wannierization,
     svd_projection,
     von_neumann,
+    upsample,
+    bandfold,
 )
+from qten.geometries.basis_transform import BasisTransform
 from qten.geometries.boundary import PeriodicBoundary
 from qten.geometries.fourier import fourier_transform
 from qten.geometries.spatials import AffineSpace, KPointSet, Lattice, Offset
@@ -61,6 +64,149 @@ def _band_tensor() -> tuple[Tensor, HilbertSpace]:
     data = torch.diag_embed(energies).to(torch.complex128)
     tensor = Tensor(data=data, dims=(k_space, band_space, band_space))
     return tensor, band_space
+
+
+def test_upsample_1d_tight_binding_is_exact_and_keeps_old_points():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix([[1]]),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+    )
+    k_space = brillouin_zone(lattice.dual)
+    bands = _space("orb", 1)
+    k = torch.tensor(
+        [float(point.rep[0, 0]) for point in k_space.elements()], dtype=torch.float64
+    )
+    data = (1.0 + 2.0 * torch.cos(2 * torch.pi * k))[:, None, None]
+
+    tensor = Tensor(data=data, dims=(k_space, bands, bands))
+    unchanged = upsample(tensor, (1,))
+    result = upsample(tensor, (3,))
+    new_k = torch.tensor(
+        [float(point.rep[0, 0]) for point in result.dims[0].elements()],
+        dtype=torch.float64,
+    )
+    expected = 1.0 + 2.0 * torch.cos(2 * torch.pi * new_k)
+
+    assert result.data.shape == (12, 1, 1)
+    assert unchanged.dims == tensor.dims
+    assert torch.allclose(unchanged.data, tensor.data, atol=1e-12)
+    assert result.data.dtype == torch.float64
+    assert torch.allclose(result.data[:, 0, 0], expected, atol=1e-12)
+    old_values = {
+        str(point): data[i, 0, 0] for i, point in enumerate(k_space.elements())
+    }
+    for i, point in enumerate(result.dims[0].elements()):
+        if str(point) in old_values:
+            assert torch.allclose(
+                result.data[i, 0, 0], old_values[str(point)], atol=1e-12
+            )
+
+
+def test_upsample_matrix_skew_cell_and_autograd():
+    boundary = ImmutableDenseMatrix([[2, 1], [0, 2]])
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(2),
+        boundaries=PeriodicBoundary(boundary),
+    )
+    k_space = brillouin_zone(lattice.dual)
+    bands = _space("orb", 2)
+    base = torch.tensor([[1.0, 1.0j], [-1.0j, -1.0]], dtype=torch.complex128)
+    data = base.expand(k_space.dim, -1, -1).clone().requires_grad_(True)
+
+    result = upsample(Tensor(data=data, dims=(k_space, bands, bands)), (2, 3))
+
+    assert result.data.shape == (k_space.dim * 6, 2, 2)
+    assert result.data.dtype == torch.complex128
+    assert result.data.device == data.device
+    assert torch.allclose(result.data, base.expand_as(result.data), atol=1e-12)
+    assert torch.allclose(result.data, result.data.mH, atol=1e-12)
+    expected_boundary = boundary @ ImmutableDenseMatrix.diag(2, 3)
+    assert result.dims[0].extract(Lattice).boundaries.basis == expected_boundary
+    result.data.real.sum().backward()
+    assert data.grad is not None
+
+
+def test_repeated_upsample_preserves_hermiticity_and_composes():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(2),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4, 4)),
+    )
+    k_space = brillouin_zone(lattice.dual)
+    offset = Offset(rep=ImmutableDenseMatrix([0, 0]), space=lattice)
+    bands = HilbertSpace.new([_mode(offset, "a"), _mode(offset, "b")])
+    generator = torch.Generator().manual_seed(7)
+    raw = torch.randn((k_space.dim, 2, 2), generator=generator, dtype=torch.float64)
+    raw = raw + 1j * torch.randn(
+        (k_space.dim, 2, 2), generator=generator, dtype=torch.float64
+    )
+    hermitian = raw + raw.mH
+    tensor = Tensor(data=hermitian, dims=(k_space, bands, bands))
+
+    twice = upsample(upsample(tensor, (2, 2)), (2, 2))
+    direct = upsample(tensor, (4, 4))
+
+    assert torch.allclose(twice.data, twice.data.mH, atol=1e-12)
+    assert torch.allclose(twice.data, direct.data, atol=1e-12)
+
+
+def test_rectangular_upsample_does_not_build_dense_fourier_kernels(monkeypatch):
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(2),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(8, 8)),
+    )
+    k_space = brillouin_zone(lattice.dual)
+    bands = _space("orb", 2)
+    data = torch.randn((k_space.dim, bands.dim, bands.dim), dtype=torch.complex128)
+
+    def reject_dense_kernel(*args, **kwargs):
+        raise AssertionError("rectangular upsample constructed a dense kernel")
+
+    # The fallback forms its Fourier kernels with torch.exp; the FFT path does
+    # not.  This makes the memory-scaling choice an explicit regression test.
+    monkeypatch.setattr(torch, "exp", reject_dense_kernel)
+    result = upsample(Tensor(data=data, dims=(k_space, bands, bands)), (2, 2))
+
+    assert result.data.shape == (16 * 16, bands.dim, bands.dim)
+
+
+def test_upsample_rehomes_bloch_space_for_subsequent_blocking():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix([[1]]),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+    )
+    k_space = brillouin_zone(lattice.dual)
+    offset = Offset(rep=ImmutableDenseMatrix([0]), space=lattice)
+    bands = HilbertSpace.new([_mode(offset)])
+    tensor = Tensor(
+        data=torch.arange(4, dtype=torch.float64).reshape(4, 1, 1),
+        dims=(k_space, bands, bands),
+    )
+
+    result = upsample(tensor, (2,))
+    result_lattice = result.dims[0].extract(Lattice)
+    result_offset = result.dims[1].elements()[0].irrep_of(Offset)
+
+    assert result_lattice.basis == lattice.basis
+    assert result_lattice.boundaries.basis == ImmutableDenseMatrix.diag(8)
+    assert result_offset.space == result_lattice
+    folded = bandfold(BasisTransform(ImmutableDenseMatrix([[2]])), result)
+    assert folded.dims[0].dim == 4
+
+
+@pytest.mark.parametrize(
+    ("scale", "error"),
+    [((0,), ValueError), ((True,), TypeError), ((2, 2), ValueError), ([2], TypeError)],
+)
+def test_upsample_rejects_invalid_scale(scale, error):
+    tensor, _ = _band_tensor()
+    with pytest.raises(error):
+        upsample(tensor, scale)
+
+
+def test_upsample_is_available_from_ops():
+    from qten.ops import upsample as ops_upsample
+
+    assert ops_upsample is upsample
 
 
 def test_bandselect_supports_slice_criterion():

--- a/tests/test_bands.py
+++ b/tests/test_bands.py
@@ -161,9 +161,14 @@ def test_rectangular_upsample_does_not_build_dense_fourier_kernels(monkeypatch):
     def reject_dense_kernel(*args, **kwargs):
         raise AssertionError("rectangular upsample constructed a dense kernel")
 
+    def reject_centered_translation(*args, **kwargs):
+        raise AssertionError("rectangular upsample centered lattice translations")
+
     # The fallback forms its Fourier kernels with torch.exp; the FFT path does
-    # not.  This makes the memory-scaling choice an explicit regression test.
+    # not.  It also uses sympy.floor while centering lattice translations,
+    # which the rectangular path handles directly with integer indices.
     monkeypatch.setattr(torch, "exp", reject_dense_kernel)
+    monkeypatch.setattr(sy, "floor", reject_centered_translation)
     result = upsample(Tensor(data=data, dims=(k_space, bands, bands)), (2, 2))
 
     assert result.data.shape == (16 * 16, bands.dim, bands.dim)

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -717,8 +717,12 @@ def test_downsampling_gap_preimage_keeps_both_honeycomb_valleys():
         shape=(12, 12),
     )
     k_space = brillouin_zone(lattice.dual)
-    a = Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]), space=lattice)
-    b = Offset(rep=ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]), space=lattice)
+    a = Offset(
+        rep=ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]), space=lattice
+    )
+    b = Offset(
+        rep=ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]), space=lattice
+    )
     h_space = HilbertSpace.new([_mode(a, "a"), _mode(b, "b")])
 
     # Synthetic Dirac cones at K and K': gapless only there.

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -698,3 +698,52 @@ def test_downsampling_same_lattice_subset():
     assert torch.allclose(
         sampled.data, torch.tensor([[[0.0]], [[2.0]]], dtype=torch.float64)
     )
+
+
+def test_downsampling_gap_preimage_keeps_both_honeycomb_valleys():
+    """First-preimage drops K'; gap policy recovers both Dirac touchings."""
+    triangular = sy.ImmutableMatrix(
+        [
+            [sy.sqrt(3) / 2, 0],
+            [-sy.Rational(1, 2), 1],
+        ]
+    )
+    lattice = Lattice(
+        basis=triangular,
+        unit_cell={
+            "a": sy.ImmutableMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]),
+            "b": sy.ImmutableMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]),
+        },
+        shape=(12, 12),
+    )
+    k_space = brillouin_zone(lattice.dual)
+    a = Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]), space=lattice)
+    b = Offset(rep=ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]), space=lattice)
+    h_space = HilbertSpace.new([_mode(a, "a"), _mode(b, "b")])
+
+    # Synthetic Dirac cones at K and K': gapless only there.
+    data = torch.zeros(k_space.dim, 2, 2, dtype=torch.complex128)
+    for i, k in enumerate(k_space.elements()):
+        kx = float(k.rep[0, 0])
+        ky = float(k.rep[1, 0])
+        near_K = abs(kx - 1 / 3) < 1e-8 and abs(ky - 1 / 3) < 1e-8
+        near_Kp = abs(kx - 2 / 3) < 1e-8 and abs(ky - 2 / 3) < 1e-8
+        gap = 0.0 if (near_K or near_Kp) else 1.0
+        data[i, 0, 0] = gap
+        data[i, 1, 1] = -gap
+    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+
+    folded = bandfold(BasisTransform(sy.ImmutableMatrix.eye(2) * 2), tensor_in)
+    first = downsampling(tensor_in, folded.dims[0], preimage="first")
+    gap = downsampling(tensor_in, folded.dims[0], preimage="gap")
+
+    def _touching_count(sampled: Tensor) -> int:
+        count = 0
+        for block in sampled.data:
+            evals = torch.linalg.eigvalsh(0.5 * (block + block.mH))
+            if float((evals[1:] - evals[:-1]).min()) < 1e-10:
+                count += 1
+        return count
+
+    assert _touching_count(first) == 1
+    assert _touching_count(gap) == 2

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -20,7 +20,7 @@ from qten.bands import (
     bandfold,
     bandtransform,
     bandunfold,
-    downsampling,
+    cartesian_scale,
     get_band_fold,
     get_band_transform,
 )
@@ -650,104 +650,46 @@ def test_momentum_transform():
     assert new_k.space.basis == ImmutableDenseMatrix([[sy.pi]])
 
 
-def test_downsampling_matches_bandfold_momentum_space():
-    basis = ImmutableDenseMatrix([[1]])
+def test_cartesian_scale_preserves_tensor_information_and_rescales_spaces():
+    basis = ImmutableDenseMatrix.diag(2, 3, 4)
     lattice = Lattice(
         basis=basis,
-        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
-        unit_cell={"r": ImmutableDenseMatrix([0])},
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(2, 2, 2)),
+        unit_cell={"r": ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0])},
     )
     k_space = brillouin_zone(lattice.dual)
-    h_space = HilbertSpace.new(
-        [_mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice))]
-    )
-    data = torch.arange(4, dtype=torch.float64).reshape(4, 1, 1)
+    offset = Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0]), space=lattice)
+    h_space = HilbertSpace.new([_mode(offset)])
+    data = torch.arange(k_space.dim, dtype=torch.float64).reshape(k_space.dim, 1, 1)
     tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
 
-    transform = BasisTransform(ImmutableDenseMatrix([[2]]))
-    folded = bandfold(transform, tensor_in)
-    sampled = downsampling(tensor_in, folded.dims[0])
+    scaled = cartesian_scale(tensor_in, (sy.Rational(1, 2),) * 3)
 
-    assert sampled.dims[0] == folded.dims[0]
-    assert sampled.dims[1] == h_space
-    assert sampled.dims[2] == h_space
-    # First preimages: k=0 -> fold 0 (value 0), k=1/4 -> fold 1/2 (value 1)
-    assert torch.allclose(
-        sampled.data, torch.tensor([[[0.0]], [[1.0]]], dtype=torch.float64)
+    assert scaled.data is tensor_in.data
+    assert scaled.data.shape == tensor_in.data.shape
+    scaled_k = scaled.dims[0]
+    assert isinstance(scaled_k, MomentumSpace)
+    scaled_reciprocal = scaled_k.elements()[0].space
+    assert scaled_reciprocal.dual.basis == ImmutableDenseMatrix.diag(
+        1, sy.Rational(3, 2), 2
     )
+    assert scaled_reciprocal.basis == lattice.dual.basis * 2
+    assert [k.rep for k in scaled_k.elements()] == [k.rep for k in k_space.elements()]
+
+    for dim in scaled.dims[1:]:
+        assert isinstance(dim, HilbertSpace)
+        scaled_offset = dim.elements()[0].irrep_of(Offset)
+        assert scaled_offset.rep == offset.rep
+        assert scaled_offset.space == scaled_reciprocal.dual
 
 
-def test_downsampling_same_lattice_subset():
-    basis = ImmutableDenseMatrix([[1]])
-    lattice = Lattice(
-        basis=basis,
-        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
-        unit_cell={"r": ImmutableDenseMatrix([0])},
-    )
-    k_space = brillouin_zone(lattice.dual)
-    h_space = HilbertSpace.new(
-        [_mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice))]
-    )
-    data = torch.arange(4, dtype=torch.float64).reshape(4, 1, 1)
-    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+def test_cartesian_scale_rejects_invalid_scale():
+    lattice = Lattice(basis=ImmutableDenseMatrix([[2]]), shape=(2,))
+    tensor = Tensor(data=torch.arange(2), dims=(brillouin_zone(lattice.dual),))
 
-    k_subset = k_space[::2]
-    sampled = downsampling(tensor_in, k_subset)
-
-    assert sampled.dims[0] == k_subset
-    assert torch.allclose(
-        sampled.data, torch.tensor([[[0.0]], [[2.0]]], dtype=torch.float64)
-    )
-
-
-def test_downsampling_gap_preimage_keeps_both_honeycomb_valleys():
-    """First-preimage drops K'; gap policy recovers both Dirac touchings."""
-    triangular = sy.ImmutableMatrix(
-        [
-            [sy.sqrt(3) / 2, 0],
-            [-sy.Rational(1, 2), 1],
-        ]
-    )
-    lattice = Lattice(
-        basis=triangular,
-        unit_cell={
-            "a": sy.ImmutableMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]),
-            "b": sy.ImmutableMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]),
-        },
-        shape=(12, 12),
-    )
-    k_space = brillouin_zone(lattice.dual)
-    a = Offset(
-        rep=ImmutableDenseMatrix([sy.Rational(1, 3), sy.Rational(2, 3)]), space=lattice
-    )
-    b = Offset(
-        rep=ImmutableDenseMatrix([sy.Rational(2, 3), sy.Rational(1, 3)]), space=lattice
-    )
-    h_space = HilbertSpace.new([_mode(a, "a"), _mode(b, "b")])
-
-    # Synthetic Dirac cones at K and K': gapless only there.
-    data = torch.zeros(k_space.dim, 2, 2, dtype=torch.complex128)
-    for i, k in enumerate(k_space.elements()):
-        kx = float(k.rep[0, 0])
-        ky = float(k.rep[1, 0])
-        near_K = abs(kx - 1 / 3) < 1e-8 and abs(ky - 1 / 3) < 1e-8
-        near_Kp = abs(kx - 2 / 3) < 1e-8 and abs(ky - 2 / 3) < 1e-8
-        gap = 0.0 if (near_K or near_Kp) else 1.0
-        data[i, 0, 0] = gap
-        data[i, 1, 1] = -gap
-    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
-
-    folded = bandfold(BasisTransform(sy.ImmutableMatrix.eye(2) * 2), tensor_in)
-    first = downsampling(tensor_in, folded.dims[0], preimage="first")
-    gap = downsampling(tensor_in, folded.dims[0], preimage="gap")
-
-    def _touching_count(sampled: Tensor) -> int:
-        count = 0
-        for block in sampled.data:
-            evals = torch.linalg.eigvalsh(0.5 * (block + block.mH))
-            if float((evals[1:] - evals[:-1]).min()) < 1e-10:
-                count += 1
-        return count
-
-    assert _touching_count(first) == 1
-    assert _touching_count(gap) == 2
+    with pytest.raises(ValueError, match="expected 1, got 2"):
+        cartesian_scale(tensor, (1, 1))
+    with pytest.raises(ValueError, match="nonzero"):
+        cartesian_scale(tensor, (0,))
+    with pytest.raises(TypeError, match="int or sympy.Expr"):
+        cartesian_scale(tensor, (0.5,))  # type: ignore[arg-type]

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -20,6 +20,7 @@ from qten.bands import (
     bandfold,
     bandtransform,
     bandunfold,
+    downsampling,
     get_band_fold,
     get_band_transform,
 )
@@ -647,3 +648,54 @@ def test_momentum_transform():
     # Formula: new_rep = M^T @ old_rep = [2] @ [0.5] = [1]
     assert new_k.rep == ImmutableDenseMatrix([1])
     assert new_k.space.basis == ImmutableDenseMatrix([[sy.pi]])
+
+
+def test_downsampling_matches_bandfold_momentum_space():
+    basis = ImmutableDenseMatrix([[1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    h_space = HilbertSpace.new(
+        [_mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice))]
+    )
+    data = torch.arange(4, dtype=torch.float64).reshape(4, 1, 1)
+    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+
+    transform = BasisTransform(ImmutableDenseMatrix([[2]]))
+    folded = bandfold(transform, tensor_in)
+    sampled = downsampling(tensor_in, folded.dims[0])
+
+    assert sampled.dims[0] == folded.dims[0]
+    assert sampled.dims[1] == h_space
+    assert sampled.dims[2] == h_space
+    # First preimages: k=0 -> fold 0 (value 0), k=1/4 -> fold 1/2 (value 1)
+    assert torch.allclose(
+        sampled.data, torch.tensor([[[0.0]], [[1.0]]], dtype=torch.float64)
+    )
+
+
+def test_downsampling_same_lattice_subset():
+    basis = ImmutableDenseMatrix([[1]])
+    lattice = Lattice(
+        basis=basis,
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(4)),
+        unit_cell={"r": ImmutableDenseMatrix([0])},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    h_space = HilbertSpace.new(
+        [_mode(Offset(rep=ImmutableDenseMatrix([0]), space=lattice))]
+    )
+    data = torch.arange(4, dtype=torch.float64).reshape(4, 1, 1)
+    tensor_in = Tensor(data=data, dims=(k_space, h_space, h_space))
+
+    k_subset = k_space[::2]
+    sampled = downsampling(tensor_in, k_subset)
+
+    assert sampled.dims[0] == k_subset
+    assert torch.allclose(
+        sampled.data, torch.tensor([[[0.0]], [[2.0]]], dtype=torch.float64)
+    )
+

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -693,3 +693,20 @@ def test_cartesian_scale_rejects_invalid_scale():
         cartesian_scale(tensor, (0,))
     with pytest.raises(TypeError, match="int or sympy.Expr"):
         cartesian_scale(tensor, (0.5,))  # type: ignore[arg-type]
+
+
+def test_cartesian_scale_rescales_affine_space_offsets():
+    lattice = Lattice(basis=ImmutableDenseMatrix.eye(2), shape=(1, 1))
+    affine = AffineSpace(basis=ImmutableDenseMatrix.diag(2, 3))
+    offset = Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 2), 1]), space=affine)
+    hilbert = HilbertSpace.new([_mode(offset)])
+    tensor = Tensor(
+        data=torch.ones((1, 1, 1)),
+        dims=(brillouin_zone(lattice.dual), hilbert, hilbert),
+    )
+
+    scaled = cartesian_scale(tensor, (2, 3))
+
+    scaled_offset = scaled.dims[1].elements()[0].irrep_of(Offset)
+    assert scaled_offset.rep == offset.rep
+    assert scaled_offset.space == AffineSpace(basis=ImmutableDenseMatrix.diag(4, 9))

--- a/tests/test_basis_transform.py
+++ b/tests/test_basis_transform.py
@@ -698,4 +698,3 @@ def test_downsampling_same_lattice_subset():
     assert torch.allclose(
         sampled.data, torch.tensor([[[0.0]], [[2.0]]], dtype=torch.float64)
     )
-


### PR DESCRIPTION
## Summary

This PR adds two complementary operations for momentum-resolved tensors:

- `upsample` interpolates a complete Brillouin-zone matrix tensor onto a denser momentum grid using its localized/Wannier representation.
- `cartesian_scale` rescales the Cartesian lattice geometry while preserving tensor data, fractional coordinates, boundaries, unit-cell sites, and axis sizes.

It also exposes `upsample` through `qten.ops` and ignores generated image files in the repository.

## Implementation

### Momentum-grid upsampling

- Enlarges each real-space boundary generator by a positive integer scale factor and constructs the corresponding denser Brillouin-zone grid.
- Uses an FFT-based fast path for rectangular grids, avoiding dense Fourier kernels.
- Retains a general Fourier interpolation path for non-rectangular periodic cells.
- Uses centered translation representatives with deterministic handling of even-grid Nyquist modes.
- Rehomes spatial Hilbert-space offsets onto the enlarged lattice so later operations such as band folding receive consistent geometry metadata.
- Preserves input dtype, device placement, Hermiticity, and PyTorch autograd support.
- Validates tensor rank and dimensions, square Hilbert-space legs, complete canonical momentum grids, and positive integer scale factors.

### Cartesian geometry scaling

- Applies a diagonal Cartesian scale matrix to direct-lattice bases and the inverse-transpose transformation to reciprocal bases.
- Rebuilds momentum and spatial Hilbert-space dimensions against the scaled lattices.
- Shares the original tensor data without interpolation or resampling.
- Preserves fractional momentum and offset representations, periodic boundaries, and unit-cell coordinates.
- Rejects zero factors, invalid factor types, and scale vectors with the wrong spatial dimension.

## Tests

Coverage includes:

- exact interpolation of a one-dimensional tight-binding model and preservation of original grid points;
- matrix-valued interpolation on skew periodic cells;
- repeated-versus-direct upsampling consistency;
- Hermiticity, dtype, device, and autograd preservation;
- enforcement of the FFT path for rectangular grids without dense Fourier kernels;
- lattice and Bloch-space metadata updates needed for subsequent band folding;
- invalid upsampling scale and tensor-shape inputs;
- `qten.ops.upsample` availability;
- Cartesian scaling of momentum and Hilbert spaces without copying tensor data;
- Cartesian scale validation.

## Verification

```text
lint: OK
type: OK
tests: 675 passed, 52 skipped
docs: built successfully
```

## API notes

- New public function: `qten.bands.upsample`
- New convenience export: `qten.ops.upsample`
- New public function: `qten.bands.cartesian_scale`
