### PR TITLE
Add 2-D/3-D Z2 indices and split topology into Chern / Z2 packages

### DIFF
--- a/src/qten/topology/__init__.py
+++ b/src/qten/topology/__init__.py
@@ -5,8 +5,8 @@ occupied-band subspace carried by a rank-3
 [`Tensor`][qten.linalg.tensors.Tensor] with dims
 ``(MomentumSpace, HilbertSpace, HilbertSpace)``. Chern and quantum-geometry
 routines diagonalize independently at every supplied momentum. The
-three-dimensional \(\mathbb{Z}_2\) routine Fourier-interpolates the mesh so
-TRIM and Wilson strings can be sampled off the original grid.
+two- and three-dimensional \(\mathbb{Z}_2\) routine Fourier-interpolates the
+mesh so TRIM and Wilson strings can be sampled off the original grid.
 
 Core API
 --------
@@ -21,8 +21,8 @@ Core API
   First Chern number computed either with discrete FHS link variables or by
   integrating the finite-difference Berry curvature.
 - [`z2_indices`][qten.topology.z2_indices]
-  Three-dimensional \(\mathbb{Z}_2\) indices from Fu--Kane inversion parities
-  or hybrid-Wannier Wilson loops.
+  Two- and three-dimensional \(\mathbb{Z}_2\) indices from Fu--Kane inversion
+  parities or hybrid-Wannier Wilson loops.
 
 Submodules
 ----------
@@ -30,7 +30,7 @@ Submodules
   Quantum geometric tensor, Fubini--Study metric, Berry curvature, and Chern
   number.
 - [`qten.topology.z2`][qten.topology.z2]
-  Three-dimensional \(\mathbb{Z}_2\) invariants.
+  Two- and three-dimensional \(\mathbb{Z}_2\) invariants.
 """
 
 from .chern import (

--- a/src/qten/topology/__init__.py
+++ b/src/qten/topology/__init__.py
@@ -3,9 +3,10 @@ r"""Quantum geometry and topology of momentum-resolved band Hamiltonians.
 This package computes geometric and topological properties of an isolated
 occupied-band subspace carried by a rank-3
 [`Tensor`][qten.linalg.tensors.Tensor] with dims
-``(MomentumSpace, HilbertSpace, HilbertSpace)``. The Hamiltonian is
-diagonalized independently at every momentum, and the ``n_occupied``
-lowest-energy eigenvectors define the occupied projector \(P(k)\).
+``(MomentumSpace, HilbertSpace, HilbertSpace)``. Chern and quantum-geometry
+routines diagonalize independently at every supplied momentum. The
+three-dimensional \(\mathbb{Z}_2\) routine Fourier-interpolates the mesh so
+TRIM and Wilson strings can be sampled off the original grid.
 
 Core API
 --------

--- a/src/qten/topology/__init__.py
+++ b/src/qten/topology/__init__.py
@@ -1,0 +1,70 @@
+r"""Quantum geometry and topology of momentum-resolved band Hamiltonians.
+
+This package computes geometric and topological properties of an isolated
+occupied-band subspace carried by a rank-3
+[`Tensor`][qten.linalg.tensors.Tensor] with dims
+``(MomentumSpace, HilbertSpace, HilbertSpace)``. The Hamiltonian is
+diagonalized independently at every momentum, and the ``n_occupied``
+lowest-energy eigenvectors define the occupied projector \(P(k)\).
+
+Core API
+--------
+- [`quantum_geometric_tensor`][qten.topology.quantum_geometric_tensor]
+  Gauge-invariant quantum geometric tensor obtained from finite differences
+  of the occupied projector.
+- [`fubini_study_metric`][qten.topology.fubini_study_metric]
+  Symmetric metric given by the real part of the quantum geometric tensor.
+- [`berry_curvature`][qten.topology.berry_curvature]
+  Local Berry curvature given by its imaginary antisymmetric part.
+- [`chern_number`][qten.topology.chern_number]
+  First Chern number computed either with discrete FHS link variables or by
+  integrating the finite-difference Berry curvature.
+- [`z2_indices`][qten.topology.z2_indices]
+  Three-dimensional \(\mathbb{Z}_2\) indices from Fu--Kane inversion parities
+  or hybrid-Wannier Wilson loops.
+
+Submodules
+----------
+- [`qten.topology.chern`][qten.topology.chern]
+  Quantum geometric tensor, Fubini--Study metric, Berry curvature, and Chern
+  number.
+- [`qten.topology.z2`][qten.topology.z2]
+  Three-dimensional \(\mathbb{Z}_2\) invariants.
+"""
+
+from .chern import (
+    FHSResult as FHSResult,
+    QGTResult as QGTResult,
+    berry_curvature as berry_curvature,
+    chern_number as chern_number,
+    fubini_study_metric as fubini_study_metric,
+    quantum_geometric_tensor as quantum_geometric_tensor,
+)
+from .z2 import (
+    Z2CombinedResult as Z2CombinedResult,
+    Z2ParityResult as Z2ParityResult,
+    Z2ParityTrimDiagnostics as Z2ParityTrimDiagnostics,
+    Z2WilsonPlaneResult as Z2WilsonPlaneResult,
+    Z2WilsonResult as Z2WilsonResult,
+    z2_indices as z2_indices,
+)
+
+from . import chern as chern
+from . import z2 as z2
+
+__all__ = [
+    "FHSResult",
+    "QGTResult",
+    "Z2CombinedResult",
+    "Z2ParityResult",
+    "Z2ParityTrimDiagnostics",
+    "Z2WilsonPlaneResult",
+    "Z2WilsonResult",
+    "berry_curvature",
+    "chern",
+    "chern_number",
+    "fubini_study_metric",
+    "quantum_geometric_tensor",
+    "z2",
+    "z2_indices",
+]

--- a/src/qten/topology/chern.py
+++ b/src/qten/topology/chern.py
@@ -219,8 +219,8 @@ def quantum_geometric_tensor(
     bloch_hamiltonian : Tensor
         Rank-3 Hermitian [`Tensor`][qten.linalg.tensors.Tensor] with dims
         ``(MomentumSpace, HilbertSpace, HilbertSpace)``. The final two data
-        axes must be square and represent the Bloch Hamiltonian at each
-        momentum.
+        axes must be square Hilbert-space matrices at each momentum and are
+        aligned onto a common Hilbert space.
     n_occupied : int | None, optional
         Number of lowest-energy bands included in the occupied projector.
         Defaults to half the Hamiltonian bands using integer division.
@@ -520,7 +520,8 @@ def chern_number(
         Rank-3 Hermitian [`Tensor`][qten.linalg.tensors.Tensor] with dims
         ``(MomentumSpace, HilbertSpace, HilbertSpace)``. The first data axis
         enumerates a complete two-dimensional reciprocal quotient; the last
-        two axes are square Bloch-Hamiltonian matrices.
+        two axes are square Bloch-Hamiltonian matrices and are aligned onto
+        a common Hilbert space.
     n_occupied : int | None, optional
         Number of lowest-energy bands defining the occupied subspace. It must
         lie strictly between zero and the total band count. Defaults to half

--- a/src/qten/topology/chern.py
+++ b/src/qten/topology/chern.py
@@ -18,6 +18,8 @@ Core API
 - [`chern_number`][qten.topology.chern_number]
   First Chern number computed either with discrete FHS link variables or by
   integrating the finite-difference Berry curvature.
+- [`FHSResult`][qten.topology.FHSResult], [`QGTResult`][qten.topology.QGTResult]
+  Result mappings returned by ``method="fhs"`` and ``method="qgt"``.
 
 Mathematical convention
 -----------------------
@@ -411,7 +413,31 @@ def berry_curvature(
 
 
 class FHSResult(TypedDict):
-    """Result returned by the discrete FHS Chern-number method."""
+    r"""Result of [`chern_number(..., method="fhs")`][qten.topology.chern_number].
+
+    Discrete Fukui--Hatsugai--Suzuki Chern number on a complete 2-D
+    reciprocal mesh. The runtime object is a plain ``dict``.
+
+    Attributes
+    ----------
+    chern : float
+        Sum of oriented plaquette phases divided by \(2\pi\).
+    nearest_integer : int
+        ``numpy.rint(chern)`` as a convenience diagnostic, not a proof that
+        the bundle is isolated.
+    direct_gap : float
+        Minimum occupied-to-empty direct gap over the mesh.
+    berry_flux : Tensor
+        Plaquette phase in radians as a labeled
+        [`Tensor`][qten.linalg.tensors.Tensor] with dims ``(MomentumSpace,)``
+        and shape ``(N_k,)``. Momentum \(k\) labels the plaquette anchored at
+        \(k\); the order matches the input Hamiltonian momentum space.
+
+    See Also
+    --------
+    [`chern_number`][qten.topology.chern_number]
+        Public constructor of this mapping.
+    """
 
     chern: float
     nearest_integer: int
@@ -420,7 +446,37 @@ class FHSResult(TypedDict):
 
 
 class QGTResult(TypedDict):
-    """Result returned by the QGT-integral Chern-number method."""
+    r"""Result of [`chern_number(..., method="qgt")`][qten.topology.chern_number].
+
+    Chern number from integrated projector Berry curvature, plus the local
+    quantum-geometric tensors. The runtime object is a plain ``dict``.
+
+    Attributes
+    ----------
+    chern : float
+        \((2\pi)^{-1}\sum_k\Omega_{xy}(k)\) from central finite differences.
+        Approaches an integer only as the mesh is refined.
+    nearest_integer : int
+        ``numpy.rint(chern)`` as a convenience diagnostic.
+    direct_gap : float
+        Minimum occupied-to-empty direct gap over the mesh.
+    quantum_geometric_tensor : Tensor
+        Complex QGT with dims
+        ``(MomentumSpace, IndexSpace(2), IndexSpace(2))`` and shape
+        ``(N_k, 2, 2)``. Components are per reciprocal-grid step.
+    fubini_study_metric : Tensor
+        Real part of ``quantum_geometric_tensor``, same dims and shape.
+    berry_curvature : Tensor
+        \(\Omega_{ij}=2\operatorname{Im}Q_{ij}\), same dims and shape. The
+        \(xy\) orientation matches the FHS plaquette.
+
+    See Also
+    --------
+    [`quantum_geometric_tensor`][qten.topology.quantum_geometric_tensor]
+        Standalone QGT used to build this mapping.
+    [`chern_number`][qten.topology.chern_number]
+        Public constructor of this mapping.
+    """
 
     chern: float
     nearest_integer: int

--- a/src/qten/topology/chern.py
+++ b/src/qten/topology/chern.py
@@ -1,4 +1,4 @@
-r"""Quantum geometry and topology of momentum-resolved band Hamiltonians.
+r"""Quantum geometry and first Chern number of momentum-resolved band Hamiltonians.
 
 This module computes geometric properties of an isolated occupied-band
 subspace carried by a rank-3 [`Tensor`][qten.linalg.tensors.Tensor] with dims
@@ -66,10 +66,10 @@ import sympy as sy
 import torch
 from sympy import ImmutableDenseMatrix
 
-from .geometries import PeriodicBoundary, ReciprocalLattice
-from .linalg.decompose import eigh
-from .linalg.tensors import Tensor
-from .symbolics import HilbertSpace, IndexSpace, MomentumSpace
+from ..geometries import PeriodicBoundary, ReciprocalLattice
+from ..linalg.decompose import eigh
+from ..linalg.tensors import Tensor
+from ..symbolics import HilbertSpace, IndexSpace, MomentumSpace
 
 
 @dataclass(frozen=True)

--- a/src/qten/topology/z2.py
+++ b/src/qten/topology/z2.py
@@ -1,0 +1,953 @@
+r"""Three-dimensional \(\mathbb{Z}_2\) invariants of time-reversal-invariant
+insulators.
+
+The occupied subspace of a gapped 3-D Bloch Hamiltonian with even filling
+carries four \(\mathbb{Z}_2\) indices \((\nu_0; \nu_1\nu_2\nu_3)\). This module
+evaluates them from a rank-3
+[`Tensor`][qten.linalg.tensors.Tensor] with dims
+``(MomentumSpace, HilbertSpace, HilbertSpace)`` (or a
+[`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace] whose
+left momenta form a complete 3-D grid).
+
+The input mesh is Fourier-interpolated to a tight-binding hopping tensor so
+that time-reversal invariant momenta (TRIM) and Wilson-loop strings can be
+sampled independently of whether those points sit on the original grid.
+
+Core API
+--------
+- [`z2_indices`][qten.topology.z2_indices]
+  Fu--Kane inversion parities at the eight TRIM, hybrid-Wannier Wilson loops
+  on the six TRIM planes, or both.
+
+Numerical methods
+-----------------
+- ``method="parity"`` uses Fu--Kane products of inversion eigenvalues at the
+  eight TRIM. It requires an inversion operator: either an explicit rank-3
+  tensor in the same basis as the Hamiltonian, or orbital
+  [`Offset`][qten.geometries.spatials.Offset] labels from which spatial
+  inversion about ``inversion_center`` is assembled.
+- ``method="wilson"`` tracks hybrid Wannier charge centers on the six TRIM
+  planes. It does not need inversion symmetry.
+- ``method="auto"`` tries parity first and falls back to Wilson loops.
+- ``method="both"`` runs both constructions. The returned indices are the
+  parity values when that method succeeds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from itertools import product
+from typing import Literal, overload, TypedDict
+import math
+import warnings
+
+import numpy as np
+import sympy as sy
+import torch
+from sympy import ImmutableDenseMatrix
+
+from ..geometries import Momentum, Offset, PeriodicBoundary, ReciprocalLattice
+from ..linalg.tensors import Tensor
+from ..phys import Spin
+from ..pointgroups import pointgroup
+from ..pointgroups.elements import PointGroupOpr
+from ..pointgroups.ops import spinful_hilbert_opr_repr
+from ..symbolics import HilbertSpace, MomentumBlockSpace, MomentumSpace
+
+
+class Z2ParityTrimDiagnostics(TypedDict):
+    """Inversion-parity diagnostics at one TRIM."""
+
+    delta: int
+    parity_eigenvalues: np.ndarray
+    commutator_error: float
+    direct_gap: float
+
+
+class Z2ParityResult(TypedDict):
+    """Result returned by the Fu--Kane inversion-parity method."""
+
+    indices: tuple[int, int, int, int]
+    method: Literal["parity"]
+    parity_products: dict[tuple[int, int, int], int]
+    diagnostics: dict[tuple[int, int, int], Z2ParityTrimDiagnostics]
+    direct_gap: float
+
+
+class Z2WilsonPlaneResult(TypedDict):
+    """Hybrid-Wannier data on one TRIM plane."""
+
+    z2: int
+    wcc: np.ndarray
+    gap_pos: np.ndarray
+    sweep: np.ndarray
+    min_gap: float
+    kramers_resolved: bool
+
+
+class Z2WilsonResult(TypedDict):
+    """Result returned by the Wilson-loop method."""
+
+    indices: tuple[int, int, int, int]
+    method: Literal["wilson"]
+    planes: dict[tuple[int, float], Z2WilsonPlaneResult]
+    axis_z2: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    min_gap: float
+
+
+class Z2CombinedResult(TypedDict):
+    """Result returned when both parity and Wilson-loop methods are run."""
+
+    indices: tuple[int, int, int, int]
+    method: Literal["both"]
+    parity: Z2ParityResult
+    wilson: Z2WilsonResult
+
+
+def _rep_key(rep: ImmutableDenseMatrix) -> tuple[sy.Expr, ...]:
+    return tuple(sy.sympify(rep[i, 0]) for i in range(rep.rows))
+
+
+def _bloch_momenta(bloch_hamiltonian: Tensor) -> tuple[Momentum, ...]:
+    k_dim = bloch_hamiltonian.dims[0]
+    if isinstance(k_dim, MomentumSpace):
+        momenta = tuple(k_dim.elements())
+    elif isinstance(k_dim, MomentumBlockSpace):
+        momenta = tuple(pair[0] for pair in k_dim.elements())
+    else:
+        raise TypeError(
+            "The first dimension must be a MomentumSpace or MomentumBlockSpace."
+        )
+    if momenta and isinstance(momenta[0], tuple):
+        momenta = tuple(pair[0] for pair in momenta)
+    return momenta
+
+
+def _fourier_interpolate(
+    hoppings: torch.Tensor,
+    k_frac: torch.Tensor | np.ndarray | Sequence[float],
+    rx: torch.Tensor,
+    ry: torch.Tensor,
+    rz: torch.Tensor,
+) -> torch.Tensor:
+    real_dtype = hoppings.real.dtype
+    k_frac = torch.as_tensor(k_frac, device=hoppings.device, dtype=real_dtype)
+    batched = k_frac.ndim == 2
+    if not batched:
+        k_frac = k_frac[None, :]
+    phase = hoppings.new_tensor(-2j * math.pi)
+    px = torch.exp(phase * k_frac[:, 0, None] * rx[None, :])
+    py = torch.exp(phase * k_frac[:, 1, None] * ry[None, :])
+    pz = torch.exp(phase * k_frac[:, 2, None] * rz[None, :])
+    values = torch.einsum("xyzab,kx,ky,kz->kab", hoppings, px, py, pz)
+    return values if batched else values[0]
+
+
+def _indices_from_deltas(
+    parity_products: dict[tuple[int, int, int], int],
+) -> tuple[int, int, int, int]:
+    strong = math.prod(parity_products.values())
+    weak = tuple(
+        math.prod(delta for bits, delta in parity_products.items() if bits[axis] == 1)
+        for axis in range(3)
+    )
+    return (int(strong < 0), *(int(product < 0) for product in weak))
+
+
+def _largest_gap_position(wcc: np.ndarray) -> float:
+    wcc = np.sort(np.asarray(wcc, dtype=float) % 1.0)
+    extended = np.concatenate([wcc, [wcc[0] + 1.0]])
+    gaps = np.diff(extended)
+    index = int(np.argmax(gaps))
+    return float((extended[index] + 0.5 * gaps[index]) % 1.0)
+
+
+def _sgng(gap_left: float, gap_right: float, wcc_pos: float) -> int:
+    dz = (gap_right - gap_left) % 1.0
+    dx = (wcc_pos - gap_left) % 1.0
+    if dz == 0.0:
+        return 1
+    if dz <= 0.5:
+        crossed = 0.0 < dx < dz
+    else:
+        crossed = dx > dz
+    return -1 if crossed else 1
+
+
+def _kramers_pairs(wcc: np.ndarray, tolerance: float) -> bool:
+    wcc = np.sort(np.asarray(wcc, dtype=float) % 1.0)
+    n = len(wcc)
+    if n % 2:
+        return False
+    used = np.zeros(n, dtype=bool)
+    for i in range(n):
+        if used[i]:
+            continue
+        delta = np.minimum((wcc - wcc[i]) % 1.0, (wcc[i] - wcc) % 1.0)
+        delta[i] = np.inf
+        delta[used] = np.inf
+        partner = int(np.argmin(delta))
+        if not np.isfinite(delta[partner]) or delta[partner] > tolerance:
+            return False
+        used[i] = True
+        used[partner] = True
+    return True
+
+
+def _inversion_element():
+    for element in pointgroup("-1").elements():
+        dim = element.irrep.rows
+        if sy.simplify(element.irrep + sy.eye(dim)) == sy.zeros(dim):
+            return element
+    raise RuntimeError("Point group -1 does not contain spatial inversion.")
+
+
+def _as_inversion_center(
+    inversion_center: Offset | Sequence[float],
+    lattice,
+) -> Offset:
+    if isinstance(inversion_center, Offset):
+        return inversion_center.rebase(lattice)
+    values = [sy.sympify(value) for value in inversion_center]
+    if len(values) != lattice.dim:
+        raise ValueError(
+            f"inversion_center must have length {lattice.dim}, got {len(values)}."
+        )
+    return Offset(rep=ImmutableDenseMatrix(values), space=lattice)
+
+
+@dataclass
+class _Z2Engine:
+    hoppings: torch.Tensor
+    rx: torch.Tensor
+    ry: torch.Tensor
+    rz: torch.Tensor
+    tau: torch.Tensor
+    n_occupied: int
+    n_bands: int
+    lattice: object
+    inversion_hoppings: torch.Tensor | None
+    inversion_i0: torch.Tensor | None
+    inversion_center_vec: torch.Tensor | None
+    positions_cart: torch.Tensor | None
+
+    def hamiltonians_at(
+        self, k_frac: torch.Tensor | np.ndarray | Sequence[float]
+    ) -> torch.Tensor:
+        ham = _fourier_interpolate(self.hoppings, k_frac, self.rx, self.ry, self.rz)
+        return 0.5 * (ham + ham.transpose(-1, -2).conj())
+
+    def inversion_at_trim(self, trim_frac: torch.Tensor) -> torch.Tensor:
+        if self.inversion_hoppings is not None:
+            return _fourier_interpolate(
+                self.inversion_hoppings, trim_frac, self.rx, self.ry, self.rz
+            )
+        if (
+            self.inversion_i0 is None
+            or self.inversion_center_vec is None
+            or self.positions_cart is None
+        ):
+            raise RuntimeError(
+                "Cannot build inversion without Offset-labeled orbitals "
+                "or an explicit inversion tensor."
+            )
+        k_cart = torch.tensor(
+            [
+                float(c)
+                for c in Momentum(
+                    rep=ImmutableDenseMatrix(
+                        [float(x) for x in trim_frac.detach().cpu().reshape(-1)]
+                    ),
+                    space=self.lattice.dual,
+                ).to_vec()
+            ],
+            dtype=self.inversion_i0.real.dtype,
+            device=self.inversion_i0.device,
+        )
+        relative = (
+            self.positions_cart.to(
+                device=self.inversion_i0.device, dtype=self.inversion_i0.real.dtype
+            )
+            - self.inversion_center_vec.to(
+                device=self.inversion_i0.device, dtype=self.inversion_i0.real.dtype
+            )
+        ) @ k_cart
+        return self.inversion_i0 * torch.exp(
+            -1j * (relative[:, None] + relative[None, :])
+        )
+
+    def run_parity(self, parity_tolerance: float) -> Z2ParityResult:
+        parity_products: dict[tuple[int, int, int], int] = {}
+        diagnostics: dict[tuple[int, int, int], Z2ParityTrimDiagnostics] = {}
+        real_dtype = self.hoppings.real.dtype
+        device = self.hoppings.device
+        for bits in product((0, 1), repeat=3):
+            k_frac = torch.tensor(bits, dtype=real_dtype, device=device) / 2
+            ham = self.hamiltonians_at(k_frac)
+            inv_matrix = self.inversion_at_trim(k_frac)
+            ham = ham.to(dtype=inv_matrix.dtype)
+            ham_norm = torch.linalg.matrix_norm(ham).clamp_min(1.0)
+            comm = float(
+                (
+                    torch.linalg.matrix_norm(ham @ inv_matrix - inv_matrix @ ham)
+                    / ham_norm
+                ).item()
+            )
+            energies, vectors = torch.linalg.eigh(ham)
+            occupied = vectors[:, : self.n_occupied]
+            parity_matrix = occupied.conj().transpose(-2, -1) @ inv_matrix @ occupied
+            parity_matrix = 0.5 * (
+                parity_matrix + parity_matrix.conj().transpose(-2, -1)
+            )
+            peig = torch.linalg.eigvalsh(parity_matrix).real
+            parity_error = float((peig.abs() - 1).abs().max().item())
+            if comm > parity_tolerance or parity_error > parity_tolerance:
+                raise RuntimeError(
+                    f"Inversion is not resolved at TRIM {bits}: "
+                    f"commutator={comm:.3e}, parity error={parity_error:.3e}."
+                )
+            n_odd = int((peig < 0).sum().item())
+            if n_odd % 2:
+                raise RuntimeError(
+                    f"TRIM {bits} has an odd number of negative parities."
+                )
+            delta = -1 if (n_odd // 2) % 2 else 1
+            parity_products[bits] = delta
+            if self.n_occupied < self.n_bands:
+                gap = float(
+                    (energies[self.n_occupied] - energies[self.n_occupied - 1]).item()
+                )
+            else:
+                gap = float("nan")
+            diagnostics[bits] = {
+                "delta": delta,
+                "parity_eigenvalues": peig.detach().cpu().numpy(),
+                "commutator_error": comm,
+                "direct_gap": gap,
+            }
+        gaps = [item["direct_gap"] for item in diagnostics.values()]
+        finite_gaps = [gap for gap in gaps if math.isfinite(gap)]
+        direct_gap = min(finite_gaps) if finite_gaps else float("nan")
+        return {
+            "indices": _indices_from_deltas(parity_products),
+            "method": "parity",
+            "parity_products": parity_products,
+            "diagnostics": diagnostics,
+            "direct_gap": direct_gap,
+        }
+
+    def _unitary_overlap(
+        self, left: torch.Tensor, right: torch.Tensor, dk: torch.Tensor
+    ) -> torch.Tensor:
+        phases = torch.exp(
+            1j
+            * (2.0 * math.pi)
+            * (self.tau @ dk.to(dtype=self.tau.dtype, device=self.tau.device))
+        )
+        left = left * phases[:, None].to(dtype=left.dtype)
+        matrix = left.conj().transpose(-2, -1) @ right
+        u_svd, _, vh = torch.linalg.svd(matrix, full_matrices=False)
+        return u_svd @ vh
+
+    def _wilson_wcc(
+        self, k_string: np.ndarray, loop_axis: int
+    ) -> tuple[np.ndarray, float]:
+        ham = self.hamiltonians_at(k_string)
+        energies, vectors = torch.linalg.eigh(ham)
+        occupied = vectors[..., : self.n_occupied]
+        if self.n_occupied < self.n_bands:
+            gaps = energies[:, self.n_occupied] - energies[:, self.n_occupied - 1]
+            min_gap = float(gaps.min().real.item())
+        else:
+            min_gap = float("nan")
+        n_pts = occupied.shape[0]
+        wilson = None
+        dk = occupied.new_zeros(3, dtype=self.tau.dtype)
+        dk[loop_axis] = 1.0 / n_pts
+        for i in range(n_pts):
+            step = self._unitary_overlap(occupied[i], occupied[(i + 1) % n_pts], dk)
+            wilson = step if wilson is None else wilson @ step
+        evals = torch.linalg.eigvals(wilson)
+        wcc = (torch.angle(evals) / (2 * math.pi)) % 1.0
+        return np.sort(wcc.detach().real.cpu().numpy()), min_gap
+
+    def _plane_z2(
+        self,
+        normal: int,
+        trim_value: float,
+        n_loop: int,
+        n_perp: int,
+        kramers_tolerance: float,
+    ) -> Z2WilsonPlaneResult:
+        loop_axis = (normal + 1) % 3
+        sweep_axis = (normal + 2) % 3
+        sweep = np.linspace(0.0, 0.5, n_perp)
+        loop = np.linspace(0.0, 1.0, n_loop, endpoint=False)
+        wcc_list = []
+        min_gap = math.inf
+        for ky in sweep:
+            k_string = np.zeros((n_loop, 3), dtype=float)
+            k_string[:, normal] = trim_value
+            k_string[:, sweep_axis] = ky
+            k_string[:, loop_axis] = loop
+            wcc, gap = self._wilson_wcc(k_string, loop_axis)
+            wcc_list.append(wcc)
+            if math.isfinite(gap):
+                min_gap = min(min_gap, gap)
+        kramers_resolved = _kramers_pairs(
+            wcc_list[0], kramers_tolerance
+        ) and _kramers_pairs(wcc_list[-1], kramers_tolerance)
+        gap_pos = [_largest_gap_position(wcc) for wcc in wcc_list]
+        invariant = 1
+        for left, right, wcc_right in zip(gap_pos, gap_pos[1:], wcc_list[1:]):
+            for pos in wcc_right:
+                invariant *= _sgng(left, right, pos)
+        return {
+            "z2": 1 if invariant == -1 else 0,
+            "wcc": np.stack(wcc_list),
+            "gap_pos": np.asarray(gap_pos),
+            "sweep": sweep,
+            "min_gap": min_gap if math.isfinite(min_gap) else float("nan"),
+            "kramers_resolved": kramers_resolved,
+        }
+
+    def run_wilson(
+        self, n_loop: int, n_perp: int, kramers_tolerance: float
+    ) -> Z2WilsonResult:
+        if n_loop < 8 or n_perp < 5:
+            raise ValueError("n_loop must be >= 8 and n_perp must be >= 5.")
+        planes: dict[tuple[int, float], Z2WilsonPlaneResult] = {}
+        axis_z2 = []
+        for normal in range(3):
+            zero = self._plane_z2(normal, 0.0, n_loop, n_perp, kramers_tolerance)
+            pi = self._plane_z2(normal, 0.5, n_loop, n_perp, kramers_tolerance)
+            planes[(normal, 0.0)] = zero
+            planes[(normal, 0.5)] = pi
+            axis_z2.append((zero["z2"], pi["z2"]))
+        strong = [int((z0 + zpi) % 2) for z0, zpi in axis_z2]
+        indices = (strong[0], axis_z2[0][1], axis_z2[1][1], axis_z2[2][1])
+        min_gap = min(plane["min_gap"] for plane in planes.values())
+        result: Z2WilsonResult = {
+            "indices": indices,
+            "method": "wilson",
+            "planes": planes,
+            "axis_z2": (axis_z2[0], axis_z2[1], axis_z2[2]),
+            "min_gap": min_gap,
+        }
+        if len(set(strong)) != 1:
+            warnings.warn(
+                "Strong-index estimates from the three Wilson-loop axes disagree: "
+                f"{strong}. Increase n_loop / n_perp.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        unresolved = [
+            key for key, plane in planes.items() if not plane["kramers_resolved"]
+        ]
+        if unresolved:
+            warnings.warn(
+                "Kramers pairing of Wannier charge centers is not resolved on "
+                f"TRIM planes {unresolved}.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        return result
+
+
+def _orbital_geometry(
+    space,
+    lattice,
+    n_bands: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    tau = torch.zeros((n_bands, 3), dtype=dtype, device=device)
+    if not isinstance(space, HilbertSpace):
+        return tau, None
+    try:
+        positions = []
+        for i, state in enumerate(space.elements()):
+            offset = state.irrep_of(Offset)
+            positions.append(
+                torch.tensor(
+                    [float(c) for c in offset.to_vec()],
+                    dtype=torch.float64,
+                )
+            )
+            rebased = offset.rebase(lattice)
+            for j in range(3):
+                tau[i, j] = float(rebased.rep[j])
+        return tau, torch.stack(positions)
+    except Exception:
+        tau.zero_()
+        return tau, None
+
+
+def _spatial_inversion_matrix(
+    space: HilbertSpace,
+    center: Offset,
+    positions_cart: torch.Tensor,
+    n_bands: int,
+    hoppings: torch.Tensor,
+) -> torch.Tensor:
+    inv_op = PointGroupOpr(_inversion_element()).fixpoint_at(center)
+    try:
+        return spinful_hilbert_opr_repr(inv_op, space).data.to(
+            device=hoppings.device, dtype=hoppings.dtype
+        )
+    except ValueError:
+        pass
+    elements = list(space.elements())
+    center_vec = torch.tensor([float(c) for c in center.to_vec()], dtype=torch.float64)
+    target = 2.0 * center_vec - positions_cart
+    i0 = hoppings.new_zeros((n_bands, n_bands))
+    spins: list[object | None] = []
+    for state in elements:
+        try:
+            spins.append(state.irrep_of(Spin))
+        except Exception:
+            spins.append(None)
+    used = set()
+    for i in range(n_bands):
+        delta = (positions_cart - target[i]).square().sum(dim=-1).clone()
+        for j, spin in enumerate(spins):
+            if spins[i] is not None and spin != spins[i]:
+                delta[j] = math.inf
+            if j in used:
+                delta[j] = math.inf
+        j = int(torch.argmin(delta).item())
+        if not math.isfinite(float(delta[j].item())) or float(delta[j].item()) > 1e-6:
+            raise RuntimeError("Orbital space is not closed under spatial inversion.")
+        i0[j, i] = 1
+        used.add(j)
+    return i0
+
+
+def _build_engine(
+    bloch_hamiltonian: Tensor,
+    n_occupied: int | None,
+    inversion: Tensor | None,
+    inversion_center: Offset | Sequence[float] | None,
+) -> _Z2Engine:
+    if bloch_hamiltonian.rank() != 3:
+        raise ValueError("bloch_hamiltonian must have dimensions (k, band, band).")
+    if not isinstance(bloch_hamiltonian.dims[1], HilbertSpace):
+        raise TypeError("The second dimension must be a HilbertSpace.")
+    if not isinstance(bloch_hamiltonian.dims[2], HilbertSpace):
+        raise TypeError("The third dimension must be a HilbertSpace.")
+
+    data = bloch_hamiltonian.data
+    if data.shape[-2] != data.shape[-1]:
+        raise ValueError("The Hamiltonian must be square at every momentum.")
+    n_bands = int(data.shape[-1])
+    if n_occupied is None:
+        n_occupied = n_bands // 2
+    n_occupied = int(n_occupied)
+    if not 0 < n_occupied <= n_bands:
+        raise ValueError("n_occupied must lie between 1 and n_bands.")
+    if n_occupied % 2:
+        raise ValueError("Z2 requires an even occupied count (Kramers pairs).")
+
+    momenta = _bloch_momenta(bloch_hamiltonian)
+    if not momenta or len(momenta[0].rep) != 3:
+        raise ValueError("A three-dimensional momentum grid is required.")
+
+    reciprocal_lattice = momenta[0].space
+    if not isinstance(reciprocal_lattice, ReciprocalLattice):
+        raise TypeError("Momentum points must belong to a ReciprocalLattice.")
+    lattice = reciprocal_lattice.lattice
+    direct_boundary = lattice.boundaries
+    if not isinstance(direct_boundary, PeriodicBoundary):
+        raise ValueError("The momentum grid requires periodic lattice boundaries.")
+    dual_boundary = PeriodicBoundary(ImmutableDenseMatrix(direct_boundary.basis.T))
+    grid_shape = tuple(int(n) for n in lattice.shape)
+    if len(grid_shape) != 3:
+        raise ValueError("A three-dimensional momentum grid is required.")
+    n_k = math.prod(grid_shape)
+    if n_k != len(momenta):
+        raise ValueError(
+            f"Found {len(momenta)} momenta, but the lattice shape is {grid_shape}."
+        )
+
+    canonical_reps = dual_boundary.representatives()
+    if len(canonical_reps) != n_k:
+        raise ValueError("Momentum points do not form a complete reciprocal grid.")
+    canonical_position = {
+        _rep_key(rep): position for position, rep in enumerate(canonical_reps)
+    }
+
+    h_grid = data.new_zeros((*grid_shape, n_bands, n_bands))
+    seen: set[tuple[int, int, int]] = set()
+    for sector, momentum in enumerate(momenta):
+        integer_rep = ImmutableDenseMatrix(direct_boundary.basis.T @ momentum.rep)
+        if any(not sy.sympify(value).is_integer for value in integer_rep):
+            raise ValueError(
+                "Momentum grid contains a point outside the reciprocal quotient."
+            )
+        key = _rep_key(dual_boundary.wrap(integer_rep))
+        if key not in canonical_position:
+            raise ValueError(
+                f"Duplicate or incomplete momentum quotient representative {key}."
+            )
+        index = tuple(
+            int(i) for i in np.unravel_index(canonical_position[key], grid_shape)
+        )
+        if index in seen:
+            raise ValueError(f"Duplicate momentum grid point {index}.")
+        seen.add(index)
+        h_grid[index] = data[sector]
+    if len(seen) != n_k:
+        raise ValueError("Momentum points do not form a complete reciprocal grid.")
+
+    h_grid = 0.5 * (h_grid + h_grid.transpose(-1, -2).conj())
+    hoppings = torch.fft.ifftn(h_grid, dim=(0, 1, 2))
+    device = hoppings.device
+    real_dtype = hoppings.real.dtype
+    rx = (torch.fft.fftfreq(grid_shape[0], dtype=real_dtype) * grid_shape[0]).to(device)
+    ry = (torch.fft.fftfreq(grid_shape[1], dtype=real_dtype) * grid_shape[1]).to(device)
+    rz = (torch.fft.fftfreq(grid_shape[2], dtype=real_dtype) * grid_shape[2]).to(device)
+
+    space = bloch_hamiltonian.dims[1]
+    tau, positions_cart = _orbital_geometry(space, lattice, n_bands, device, real_dtype)
+
+    inversion_hoppings = None
+    inversion_i0 = None
+    inversion_center_vec = None
+    if inversion is not None:
+        if inversion.rank() != 3 or inversion.data.shape != data.shape:
+            raise ValueError("inversion must match bloch_hamiltonian's rank and shape.")
+        inv_grid = inversion.data.new_zeros((*grid_shape, n_bands, n_bands))
+        for sector, momentum in enumerate(momenta):
+            integer_rep = ImmutableDenseMatrix(direct_boundary.basis.T @ momentum.rep)
+            key = _rep_key(dual_boundary.wrap(integer_rep))
+            index = tuple(
+                int(i) for i in np.unravel_index(canonical_position[key], grid_shape)
+            )
+            inv_grid[index] = inversion.data[sector]
+        inversion_hoppings = torch.fft.ifftn(inv_grid, dim=(0, 1, 2))
+    elif isinstance(space, HilbertSpace) and positions_cart is not None:
+        if inversion_center is None:
+            unique_reps: list[tuple[sy.Expr, ...]] = []
+            for state in space.elements():
+                frac = state.irrep_of(Offset).rebase(lattice).fractional()
+                rep = tuple(sy.simplify(frac.rep[j]) for j in range(3))
+                if rep not in unique_reps:
+                    unique_reps.append(rep)
+            n_sites = len(unique_reps)
+            center_rep = sy.Matrix(
+                [
+                    sy.simplify(sum(rep[j] for rep in unique_reps) / n_sites)
+                    for j in range(3)
+                ]
+            )
+            center = Offset(rep=ImmutableDenseMatrix(center_rep), space=lattice)
+        else:
+            center = _as_inversion_center(inversion_center, lattice)
+        try:
+            inversion_i0 = _spatial_inversion_matrix(
+                space, center, positions_cart, n_bands, hoppings
+            )
+            inversion_center_vec = torch.tensor(
+                [float(c) for c in center.to_vec()], dtype=torch.float64
+            )
+        except Exception:
+            inversion_i0 = None
+            inversion_center_vec = None
+
+    return _Z2Engine(
+        hoppings=hoppings,
+        rx=rx,
+        ry=ry,
+        rz=rz,
+        tau=tau,
+        n_occupied=n_occupied,
+        n_bands=n_bands,
+        lattice=lattice,
+        inversion_hoppings=inversion_hoppings,
+        inversion_i0=inversion_i0,
+        inversion_center_vec=inversion_center_vec,
+        positions_cart=positions_cart,
+    )
+
+
+@overload
+def z2_indices(
+    bloch_hamiltonian: Tensor,
+    n_occupied: int | None = None,
+    *,
+    method: Literal["auto"] = "auto",
+    inversion: Tensor | None = None,
+    inversion_center: Offset | Sequence[float] | None = None,
+    n_loop: int = 32,
+    n_perp: int = 17,
+    parity_tolerance: float = 1e-5,
+    kramers_tolerance: float = 0.08,
+    gap_tolerance: float = 1e-8,
+) -> Z2ParityResult | Z2WilsonResult: ...
+
+
+@overload
+def z2_indices(
+    bloch_hamiltonian: Tensor,
+    n_occupied: int | None = None,
+    *,
+    method: Literal["parity"],
+    inversion: Tensor | None = None,
+    inversion_center: Offset | Sequence[float] | None = None,
+    n_loop: int = 32,
+    n_perp: int = 17,
+    parity_tolerance: float = 1e-5,
+    kramers_tolerance: float = 0.08,
+    gap_tolerance: float = 1e-8,
+) -> Z2ParityResult: ...
+
+
+@overload
+def z2_indices(
+    bloch_hamiltonian: Tensor,
+    n_occupied: int | None = None,
+    *,
+    method: Literal["wilson"],
+    inversion: Tensor | None = None,
+    inversion_center: Offset | Sequence[float] | None = None,
+    n_loop: int = 32,
+    n_perp: int = 17,
+    parity_tolerance: float = 1e-5,
+    kramers_tolerance: float = 0.08,
+    gap_tolerance: float = 1e-8,
+) -> Z2WilsonResult: ...
+
+
+@overload
+def z2_indices(
+    bloch_hamiltonian: Tensor,
+    n_occupied: int | None = None,
+    *,
+    method: Literal["both"],
+    inversion: Tensor | None = None,
+    inversion_center: Offset | Sequence[float] | None = None,
+    n_loop: int = 32,
+    n_perp: int = 17,
+    parity_tolerance: float = 1e-5,
+    kramers_tolerance: float = 0.08,
+    gap_tolerance: float = 1e-8,
+) -> Z2CombinedResult: ...
+
+
+def z2_indices(
+    bloch_hamiltonian: Tensor,
+    n_occupied: int | None = None,
+    *,
+    method: Literal["auto", "parity", "wilson", "both"] = "auto",
+    inversion: Tensor | None = None,
+    inversion_center: Offset | Sequence[float] | None = None,
+    n_loop: int = 32,
+    n_perp: int = 17,
+    parity_tolerance: float = 1e-5,
+    kramers_tolerance: float = 0.08,
+    gap_tolerance: float = 1e-8,
+) -> Z2ParityResult | Z2WilsonResult | Z2CombinedResult:
+    r"""Compute the 3-D \(\mathbb{Z}_2\) indices of an occupied band subspace.
+
+    The ``n_occupied`` lowest-energy eigenstates, which must form an even
+    number of Kramers pairs, define an occupied bundle over a complete
+    three-dimensional periodic momentum grid. Two numerical methods are
+    available:
+
+    - ``method="parity"`` evaluates Fu--Kane inversion eigenvalues at the eight
+      TRIM and returns \((\nu_0; \nu_1\nu_2\nu_3)\) from their products.
+    - ``method="wilson"`` computes hybrid Wannier charge centers on the six
+      TRIM planes \(k_i=0\) and \(k_i=1/2\). The strong index is
+      \(\nu_0=\nu(k_i=0)+\nu(k_i=\pi)\bmod 2\) and the weak indices are the
+      three \(k_i=\pi\) plane invariants.
+
+    The Hamiltonian is Fourier-interpolated from the supplied mesh, so TRIM
+    and Wilson strings need not coincide with sampled \(k\)-points. This is
+    the construction used for odd diamond meshes such as \(27^3\).
+
+    Parameters
+    ----------
+    bloch_hamiltonian : Tensor
+        Rank-3 Hermitian [`Tensor`][qten.linalg.tensors.Tensor] with dims
+        ``(MomentumSpace, HilbertSpace, HilbertSpace)``, or with a
+        [`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace]
+        whose left momenta form a complete 3-D reciprocal quotient. The last
+        two axes are square Bloch-Hamiltonian matrices.
+    n_occupied : int | None, optional
+        Number of lowest-energy bands defining the occupied subspace. It must
+        be even and lie between 1 and the total band count inclusive.
+        Defaults to half the bands using integer division.
+    method : {"auto", "parity", "wilson", "both"}, optional
+        Numerical construction. ``"auto"`` tries Fu--Kane parity and falls
+        back to Wilson loops if inversion cannot be resolved. Defaults to
+        ``"auto"``.
+    inversion : Tensor | None, optional
+        Optional rank-3 inversion tensor with the same shape as
+        ``bloch_hamiltonian``. If omitted, spatial inversion is assembled from
+        orbital [`Offset`][qten.geometries.spatials.Offset] labels about
+        ``inversion_center``.
+    inversion_center : Offset | Sequence[float] | None, optional
+        Fixed point of spatial inversion, as an `Offset` or a 3-vector in the
+        Hamiltonian's direct-lattice coordinates. Defaults to the centroid of
+        the unique orbital offsets.
+    n_loop : int, optional
+        Number of Wilson-loop samples around each closed \(k\)-string.
+        Must be at least 8 when Wilson loops are evaluated. Defaults to 32.
+    n_perp : int, optional
+        Number of hybrid-Wannier samples from a TRIM plane's \(k_\perp=0\)
+        edge to \(k_\perp=\pi\). Must be at least 5 when Wilson loops are
+        evaluated. Defaults to 17.
+    parity_tolerance : float, optional
+        Maximum relative \([H,I]\) commutator and inversion-eigenvalue
+        deviation accepted at a TRIM. Defaults to ``1e-5``.
+    kramers_tolerance : float, optional
+        Maximum Wannier-center separation allowed when pairing Kramers
+        partners on TRIM-plane endpoints. Defaults to ``0.08``.
+    gap_tolerance : float, optional
+        Warning threshold for the minimum sampled occupied-to-empty direct
+        gap. Defaults to ``1e-8``.
+
+    Returns
+    -------
+    dict[str, Any]
+        Result mapping. Every method returns:
+
+        - ``"indices"``: \((\nu_0, \nu_1, \nu_2, \nu_3)\) as integers in
+          \(\{0,1\}\).
+        - ``"method"``: the construction that produced those indices.
+
+        For ``method="parity"`` the mapping also contains Fu--Kane
+        ``"parity_products"`` at each TRIM, per-TRIM ``"diagnostics"``, and
+        ``"direct_gap"``.
+
+        For ``method="wilson"`` it contains hybrid-Wannier ``"planes"``,
+        per-axis plane invariants ``"axis_z2"``, and ``"min_gap"``.
+
+        For ``method="both"`` it contains both ``"parity"`` and ``"wilson"``
+        sub-results; ``"indices"`` follows the parity values.
+
+    Raises
+    ------
+    TypeError
+        If the first tensor dimension is not a momentum space, or either
+        matrix dimension is not a `HilbertSpace`.
+    ValueError
+        If ``method`` is unsupported; the input is not a rank-3 square Bloch
+        Hamiltonian; ``n_occupied`` is invalid; the momentum space is not
+        three-dimensional and periodic; or its points do not form a unique
+        complete reciprocal quotient.
+    RuntimeError
+        For ``method="parity"``, if inversion cannot be constructed or is not
+        resolved at a TRIM.
+
+    Warns
+    -----
+    RuntimeWarning
+        If the sampled minimum direct gap is no larger than ``gap_tolerance``;
+        if ``method="auto"`` falls back from parity to Wilson loops; if the
+        three Wilson axes disagree on \(\nu_0\); if Kramers pairing of Wannier
+        centers is unresolved; or if parity and Wilson indices disagree.
+
+    Notes
+    -----
+    The Fu--Kane strong index is the product of the eight TRIM parity products
+    \(\delta(\Gamma_i)\), and each weak index \(\nu_i\) is the product of
+    \(\delta\) over the four TRIM with \(k_i=\pi\).
+
+    Examples
+    --------
+    Use Fu--Kane parities when an inversion tensor is available:
+
+    ```python
+    result = z2_indices(hamiltonian, n_occupied=2, inversion=inversion, method="parity")
+    nu0, nu1, nu2, nu3 = result["indices"]
+    ```
+
+    Fall back to Wilson loops on a system without inversion:
+
+    ```python
+    wilson = z2_indices(hamiltonian, n_occupied=2, method="wilson")
+    ```
+
+    See Also
+    --------
+    [`chern_number`][qten.topology.chern_number]
+        First Chern number of a 2-D occupied bundle.
+    """
+    method_name = str(method).lower()
+    if method_name not in {"auto", "parity", "wilson", "both"}:
+        raise ValueError("method must be 'auto', 'parity', 'wilson', or 'both'.")
+
+    engine = _build_engine(bloch_hamiltonian, n_occupied, inversion, inversion_center)
+    parity_result: Z2ParityResult | None = None
+    wilson_result: Z2WilsonResult | None = None
+
+    if method_name in {"auto", "parity", "both"}:
+        try:
+            parity_result = engine.run_parity(parity_tolerance)
+        except Exception as exc:
+            if method_name == "parity":
+                raise
+            warnings.warn(
+                f"Parity method unavailable ({exc}). Falling back to Wilson loops.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    if (
+        method_name == "wilson"
+        or method_name == "both"
+        or (method_name == "auto" and parity_result is None)
+    ):
+        wilson_result = engine.run_wilson(int(n_loop), int(n_perp), kramers_tolerance)
+
+    if method_name == "both":
+        if parity_result is None or wilson_result is None:
+            raise RuntimeError("method='both' requires parity and Wilson results.")
+        if parity_result["indices"] != wilson_result["indices"]:
+            warnings.warn(
+                f"Parity {parity_result['indices']} and Wilson "
+                f"{wilson_result['indices']} disagree.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        chosen: Z2ParityResult | Z2WilsonResult | Z2CombinedResult = {
+            "indices": parity_result["indices"],
+            "method": "both",
+            "parity": parity_result,
+            "wilson": wilson_result,
+        }
+    elif parity_result is not None and wilson_result is None:
+        chosen = parity_result
+    elif wilson_result is not None:
+        chosen = wilson_result
+    else:
+        raise RuntimeError("Z2 calculation produced no result.")
+
+    if chosen["method"] == "parity":
+        min_gap = chosen["direct_gap"]
+    elif chosen["method"] == "wilson":
+        min_gap = chosen["min_gap"]
+    else:
+        sampled = [chosen["parity"]["direct_gap"], chosen["wilson"]["min_gap"]]
+        finite = [gap for gap in sampled if math.isfinite(gap)]
+        min_gap = min(finite) if finite else float("nan")
+    if math.isfinite(min_gap) and min_gap <= gap_tolerance:
+        warnings.warn(
+            f"Minimum sampled direct gap is {min_gap:.6e}; the occupied "
+            "bundle is not isolated, so its Z2 indices are not well-defined.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return chosen
+
+
+__all__ = [
+    "Z2CombinedResult",
+    "Z2ParityResult",
+    "Z2ParityTrimDiagnostics",
+    "Z2WilsonPlaneResult",
+    "Z2WilsonResult",
+    "z2_indices",
+]

--- a/src/qten/topology/z2.py
+++ b/src/qten/topology/z2.py
@@ -18,6 +18,11 @@ Core API
 - [`z2_indices`][qten.topology.z2_indices]
   Fu--Kane inversion parities at the \(2^d\) TRIM, hybrid-Wannier Wilson
   loops, or both.
+- [`Z2ParityResult`][qten.topology.Z2ParityResult],
+  [`Z2WilsonResult`][qten.topology.Z2WilsonResult],
+  [`Z2CombinedResult`][qten.topology.Z2CombinedResult]
+  Result mappings returned by ``method="parity"``, ``"wilson"``, and
+  ``"both"``.
 
 Mathematical convention
 -----------------------
@@ -120,7 +125,8 @@ from ..geometries import Lattice, Momentum, Offset, PeriodicBoundary, Reciprocal
 from ..linalg.tensors import Tensor
 from ..phys import Spin, as_spin, contains_spin
 from ..pointgroups import pointgroup
-from ..pointgroups.elements import PointGroupOpr
+from ..pointgroups.elements import PointGroupElement, PointGroupOpr
+from ..pointgroups.finite import FinitePointGroup
 from ..pointgroups.ops import spinful_hilbert_opr_repr
 from ..symbolics import (
     HilbertSpace,
@@ -133,7 +139,29 @@ from ..symbolics import (
 
 
 class Z2ParityTrimDiagnostics(TypedDict):
-    """Inversion-parity diagnostics at one TRIM."""
+    r"""Inversion-parity diagnostics at one time-reversal invariant momentum.
+
+    This mapping is one value in
+    [`Z2ParityResult`][qten.topology.Z2ParityResult] ``"diagnostics"``.
+    TRIM are labeled by bits \(n\in\{0,1\}^d\) with \(k=n/2\).
+
+    Attributes
+    ----------
+    delta : int
+        Fu--Kane pair-parity product \(\delta(\Gamma)=\pm 1\). Equal to
+        \((-1)^{N_-/2}\), where \(N_-\) is the number of occupied negative
+        inversion eigenvalues.
+    parity_eigenvalues : Tensor
+        Occupied inversion eigenvalues \(\xi_n(\Gamma)\) as a labeled
+        [`Tensor`][qten.linalg.tensors.Tensor] with dims
+        ``(IndexSpace(n_occupied),)`` and shape ``(n_occupied,)``.
+    commutator_error : float
+        Relative residual \(\|HI-IH\|/\|H\|\) at this TRIM. Large values mean
+        the supplied or assembled inversion does not commute with \(H(\Gamma)\).
+    direct_gap : float
+        Occupied-to-empty direct gap at this TRIM. ``nan`` if the occupied
+        count leaves no empty band.
+    """
 
     delta: int
     parity_eigenvalues: Tensor
@@ -142,7 +170,35 @@ class Z2ParityTrimDiagnostics(TypedDict):
 
 
 class Z2ParityResult(TypedDict):
-    """Result returned by the Fu--Kane inversion-parity method."""
+    r"""Result of [`z2_indices(..., method="parity")`][qten.topology.z2_indices].
+
+    Fu--Kane indices from inversion eigenvalues at the \(2^d\) TRIM. The
+    runtime object is a plain ``dict``; keys below are required.
+
+    Attributes
+    ----------
+    indices : tuple[int, ...]
+        \(\mathbb{Z}_2\) indices as integers in \(\{0,1\}\). Length 1 in two
+        dimensions, \((\nu,)\). Length 4 in three dimensions,
+        \((\nu_0, \nu_1, \nu_2, \nu_3)\).
+    method : {"parity"}
+        Construction that produced ``indices``.
+    parity_products : dict[tuple[int, ...], int]
+        TRIM bit-tuple \(n\) to \(\delta(\Gamma_n)=\pm 1\). Each key has one
+        ``0``/``1`` entry per spatial axis, with \(k_j=n_j/2\).
+    diagnostics : dict[tuple[int, ...], Z2ParityTrimDiagnostics]
+        Per-TRIM
+        [`Z2ParityTrimDiagnostics`][qten.topology.Z2ParityTrimDiagnostics]
+        with the same keys as ``parity_products``.
+    direct_gap : float
+        Minimum finite occupied-to-empty gap over the TRIM. ``nan`` if none
+        of those gaps are finite.
+
+    See Also
+    --------
+    [`z2_indices`][qten.topology.z2_indices]
+        Public constructor of this mapping.
+    """
 
     indices: tuple[int, ...]
     method: Literal["parity"]
@@ -152,7 +208,36 @@ class Z2ParityResult(TypedDict):
 
 
 class Z2WilsonPlaneResult(TypedDict):
-    """Hybrid-Wannier data on one TRIM plane."""
+    r"""Hybrid-Wannier data on one Wilson-loop plane.
+
+    In two dimensions this is one loop orientation over the Brillouin zone.
+    In three dimensions it is one TRIM plane \(k_{\mathrm{normal}}=0\) or
+    \(1/2\).
+
+    Attributes
+    ----------
+    z2 : int
+        Plane \(\mathbb{Z}_2\) invariant in \(\{0,1\}\), from the
+        Soluyanov--Vanderbilt largest-gap crossing count of the Wannier
+        centers.
+    wcc : Tensor
+        Hybrid Wannier charge centers \(\bar x_n(k_\perp)\in[0,1)\) as a
+        labeled [`Tensor`][qten.linalg.tensors.Tensor] with dims
+        ``(IndexSpace(n_perp), IndexSpace(n_occupied))`` and shape
+        ``(n_perp, n_occupied)``. The first axis follows ``sweep``.
+    gap_pos : Tensor
+        Largest-gap position on the Wannier circle at each sweep sample, as a
+        labeled tensor with dims ``(IndexSpace(n_perp),)``.
+    sweep : Tensor
+        Fractional \(k_\perp\) samples from \(0\) to \(1/2\), labeled by the
+        same ``IndexSpace(n_perp)`` as ``wcc`` and ``gap_pos``.
+    min_gap : float
+        Minimum occupied-to-empty direct gap along the Wilson strings on this
+        plane. ``nan`` if no finite gap is available.
+    kramers_resolved : bool
+        Whether Wannier centers at the TRIM-plane endpoints pair into Kramers
+        partners within ``kramers_tolerance``.
+    """
 
     z2: int
     wcc: Tensor
@@ -163,7 +248,36 @@ class Z2WilsonPlaneResult(TypedDict):
 
 
 class Z2WilsonResult(TypedDict):
-    """Result returned by the Wilson-loop method."""
+    r"""Result of [`z2_indices(..., method="wilson")`][qten.topology.z2_indices].
+
+    Hybrid-Wannier \(\mathbb{Z}_2\) indices. The runtime object is a plain
+    ``dict``; keys below are required.
+
+    Attributes
+    ----------
+    indices : tuple[int, ...]
+        Same layout as
+        [`Z2ParityResult.indices`][qten.topology.Z2ParityResult]: \((\nu,)\)
+        in 2-D or \((\nu_0, \nu_1, \nu_2, \nu_3)\) in 3-D.
+    method : {"wilson"}
+        Construction that produced ``indices``.
+    planes : dict[tuple[int, float], Z2WilsonPlaneResult]
+        Plane-resolved hybrid-Wannier data. In 2-D the key is
+        ``(loop_axis, 0.0)`` for each loop orientation. In 3-D the key is
+        ``(normal, trim)`` with ``trim`` in ``{0.0, 0.5}``.
+    axis_z2 : tuple[tuple[int, ...], ...]
+        Per-axis plane invariants. In 2-D each entry is ``(ν,)`` for one loop
+        orientation. In 3-D each entry is ``(ν(k_j=0), ν(k_j=π))``.
+    min_gap : float
+        Minimum ``min_gap`` over ``planes``. ``nan`` if none are finite.
+
+    See Also
+    --------
+    [`Z2WilsonPlaneResult`][qten.topology.Z2WilsonPlaneResult]
+        Value type stored in ``planes``.
+    [`z2_indices`][qten.topology.z2_indices]
+        Public constructor of this mapping.
+    """
 
     indices: tuple[int, ...]
     method: Literal["wilson"]
@@ -173,7 +287,29 @@ class Z2WilsonResult(TypedDict):
 
 
 class Z2CombinedResult(TypedDict):
-    """Result returned when both parity and Wilson-loop methods are run."""
+    """Result of [`z2_indices(..., method="both")`][qten.topology.z2_indices].
+
+    Both constructions are run. ``indices`` follows the Fu--Kane parity
+    values; a mismatch with Wilson emits a `RuntimeWarning`.
+
+    Attributes
+    ----------
+    indices : tuple[int, ...]
+        Copy of ``parity["indices"]``.
+    method : {"both"}
+        Construction tag for this combined mapping.
+    parity : Z2ParityResult
+        Full Fu--Kane
+        [`Z2ParityResult`][qten.topology.Z2ParityResult].
+    wilson : Z2WilsonResult
+        Full hybrid-Wannier
+        [`Z2WilsonResult`][qten.topology.Z2WilsonResult].
+
+    See Also
+    --------
+    [`z2_indices`][qten.topology.z2_indices]
+        Public constructor of this mapping.
+    """
 
     indices: tuple[int, ...]
     method: Literal["both"]
@@ -342,20 +478,25 @@ def _kramers_spectrum(energies: torch.Tensor, tolerance: float) -> bool:
     return bool((pairs[:, 1] - pairs[:, 0]).max().item() <= tolerance)
 
 
+def _cartesian_components(offset: Offset) -> list[float]:
+    vector = offset.to_vec(ImmutableDenseMatrix)
+    return [float(component) for component in vector]
+
+
 def _time_reversal_matrix(
     space: HilbertSpace, like: torch.Tensor
 ) -> torch.Tensor | None:
     if not contains_spin(space):
         return None
     theta = like.new_zeros((space.dim, space.dim))
-    index_of: dict[tuple[tuple[object, ...], object], int] = {}
-    parsed: list[tuple[tuple[object, ...], object, int]] = []
+    index_of: dict[tuple[tuple[object, ...], Spin], int] = {}
+    parsed: list[tuple[tuple[object, ...], Spin, int]] = []
     for psi in space.elements():
         try:
-            spin = psi.irrep_of(Spin)
+            labeled = psi.irrep_of(Spin)
         except ValueError:
             return None
-        spin = as_spin(spin)
+        spin = as_spin(labeled)
         if spin is None:
             return None
         nons = tuple(rep for rep in psi.base if as_spin(rep) is None)
@@ -371,12 +512,18 @@ def _time_reversal_matrix(
     return theta
 
 
-def _inversion_element(dim: int):
+def _inversion_element(dim: int) -> PointGroupElement:
     if dim == 2:
         # In 2-D, r -> -r is a pi rotation. Use a trivial spin lift so the
         # operator is spatial inversion, not a spinful C2.
-        return pointgroup("c2-xy:xy", spin="trivial")
-    for element in pointgroup("-1").elements():
+        element = pointgroup("c2-xy:xy", spin="trivial")
+        if isinstance(element, FinitePointGroup):
+            raise RuntimeError("Expected a single 2-D inversion element.")
+        return element
+    group = pointgroup("-1")
+    if not isinstance(group, FinitePointGroup):
+        raise RuntimeError("Point group -1 did not return a finite group.")
+    for element in group.elements():
         irrep_dim = element.irrep.rows
         if sy.simplify(element.irrep + sy.eye(irrep_dim)) == sy.zeros(irrep_dim):
             return element
@@ -438,15 +585,14 @@ class _Z2Engine:
                 "or an explicit inversion tensor."
             )
         k_cart = torch.tensor(
-            [
-                float(c)
-                for c in Momentum(
+            _cartesian_components(
+                Momentum(
                     rep=ImmutableDenseMatrix(
                         [float(x) for x in trim_frac.detach().cpu().reshape(-1)]
                     ),
                     space=self.lattice.dual,
-                ).to_vec()
-            ],
+                )
+            ),
             dtype=self.inversion_i0.real.dtype,
             device=self.inversion_i0.device,
         )
@@ -757,20 +903,21 @@ def _orbital_geometry(
             "label every basis state or none."
         )
 
-    positions = [None] * n_bands
+    positions: list[torch.Tensor | None] = [None] * n_bands
     for state, offset in zip(states, offsets):
         assert offset is not None
         index = space.structure[state]
         positions[index] = torch.tensor(
-            [float(c) for c in offset.to_vec()],
+            _cartesian_components(offset),
             dtype=torch.float64,
         )
         rebased = offset.rebase(lattice)
         for j in range(lattice.dim):
             tau[index, j] = float(rebased.rep[j])
-    if any(item is None for item in positions):
+    resolved = [item for item in positions if item is not None]
+    if len(resolved) != n_bands:
         raise RuntimeError("Offset labels do not cover every orbital index.")
-    return tau, torch.stack([item for item in positions if item is not None])
+    return tau, torch.stack(resolved)
 
 
 def _spatial_inversion_matrix(
@@ -853,13 +1000,14 @@ def _build_engine(
     canonical_position = {
         _rep_key(rep): position for position, rep in enumerate(canonical_reps)
     }
-    scatter_kw = {
-        "direct_boundary": direct_boundary,
-        "dual_boundary": dual_boundary,
-        "grid_shape": grid_shape,
-        "canonical_position": canonical_position,
-    }
-    h_grid = _scatter_to_grid(data, momenta, **scatter_kw)
+    h_grid = _scatter_to_grid(
+        data,
+        momenta,
+        direct_boundary=direct_boundary,
+        dual_boundary=dual_boundary,
+        grid_shape=grid_shape,
+        canonical_position=canonical_position,
+    )
 
     h_grid = 0.5 * (h_grid + h_grid.transpose(-1, -2).conj())
     hoppings = torch.fft.ifftn(h_grid, dim=tuple(range(momentum_dim)))
@@ -890,7 +1038,12 @@ def _build_engine(
         if inversion.data.shape[-2:] != (n_bands, n_bands):
             raise ValueError("inversion must match bloch_hamiltonian's rank and shape.")
         inv_grid = _scatter_to_grid(
-            inversion.data, _bloch_momenta(inversion), **scatter_kw
+            inversion.data,
+            _bloch_momenta(inversion),
+            direct_boundary=direct_boundary,
+            dual_boundary=dual_boundary,
+            grid_shape=grid_shape,
+            canonical_position=canonical_position,
         )
         inversion_hoppings = torch.fft.ifftn(inv_grid, dim=tuple(range(momentum_dim)))
     elif isinstance(space, HilbertSpace) and positions_cart is not None:
@@ -914,7 +1067,7 @@ def _build_engine(
         try:
             inversion_i0 = _spatial_inversion_matrix(space, center, hoppings)
             inversion_center_vec = torch.tensor(
-                [float(c) for c in center.to_vec()], dtype=torch.float64
+                _cartesian_components(center), dtype=torch.float64
             )
         except (RuntimeError, ValueError) as exc:
             inversion_i0 = None

--- a/src/qten/topology/z2.py
+++ b/src/qten/topology/z2.py
@@ -422,9 +422,7 @@ class _Z2Engine:
 
     def inversion_at_trim(self, trim_frac: torch.Tensor) -> torch.Tensor:
         if self.inversion_hoppings is not None:
-            return _fourier_interpolate(
-                self.inversion_hoppings, trim_frac, self.r_axes
-            )
+            return _fourier_interpolate(self.inversion_hoppings, trim_frac, self.r_axes)
         if (
             self.inversion_i0 is None
             or self.inversion_center_vec is None

--- a/src/qten/topology/z2.py
+++ b/src/qten/topology/z2.py
@@ -19,11 +19,78 @@ Core API
   Fu--Kane inversion parities at the eight TRIM, hybrid-Wannier Wilson loops
   on the six TRIM planes, or both.
 
+Mathematical convention
+-----------------------
+TRIM are the eight points \(\Gamma_i=n/2\) with \(n\in\{0,1\}^3\). At each
+TRIM the occupied inversion eigenvalues \(\xi_n(\Gamma_i)=\pm 1\) come in
+Kramers pairs. Their pair product is
+
+\[
+\delta(\Gamma_i)=\prod_{m=1}^{N_{\mathrm{occ}}/2}\xi_{2m}(\Gamma_i)
+=(-1)^{N_-(\Gamma_i)/2},
+\]
+
+where \(N_-\) is the number of occupied negative parities. The returned
+indices satisfy
+
+\[
+(-1)^{\nu_0}=\prod_{i=1}^{8}\delta(\Gamma_i),
+\qquad
+(-1)^{\nu_j}=\prod_{\Gamma_i:\,k_j=\pi}\delta(\Gamma_i).
+\]
+
+Without inversion, each TRIM plane \(k_j=0\) or \(k_j=\pi\) carries a 2-D
+\(\mathbb{Z}_2\) invariant from hybrid Wannier charge centers. Along a
+closed string at fixed \(k_\perp\),
+
+\[
+W(k_\perp)=\prod_\ell
+\operatorname{polar}\!\left[
+U^\dagger(k_\ell)\,e^{-2\pi i\,\tau\cdot\Delta k}\,U(k_{\ell+1})
+\right],
+\qquad
+\bar{x}_n(k_\perp)=\frac{\operatorname{Arg}\lambda_n(W)}{2\pi}\bmod 1,
+\]
+
+where \(U(k)\) holds occupied eigenvectors and \(\tau\) is the orbital
+fractional offset. The plane invariant is the Soluyanov--Vanderbilt
+largest-gap crossing count of those centers. Then
+
+\[
+\nu_0=\nu(k_j=0)+\nu(k_j=\pi)\pmod{2},
+\qquad
+\nu_j=\nu(k_j=\pi).
+\]
+
+If the three axes disagree on \(\nu_0\), the majority vote is returned.
+
+Fourier interpolation
+---------------------
+Sampled Bloch matrices are placed on the rectangular reciprocal quotient
+and inverted with an FFT. Evaluation at fractional \(k\) is the
+trigonometric polynomial
+
+\[
+H(k)=\sum_R t(R)\,e^{-2\pi i\,k\cdot R},
+\qquad
+t=\mathcal{F}^{-1}[H_{\mathrm{mesh}}].
+\]
+
+The same interpolant is used for an explicit inversion tensor. When
+inversion is assembled from orbital offsets about a center \(c\),
+
+\[
+I_{\alpha\beta}(k)=(I_0)_{\alpha\beta}
+\exp\bigl(-i[(r_\alpha-c)+(r_\beta-c)]\cdot k_{\mathrm{cart}}\bigr).
+\]
+
+The periodic cell must be diagonal in the primitive basis.
+
 Numerical methods
 -----------------
 - ``method="parity"`` uses Fu--Kane products of inversion eigenvalues at the
   eight TRIM. It requires an inversion operator: either an explicit rank-3
-  tensor in the same basis as the Hamiltonian, or orbital
+  tensor whose matrices are paired to \(H(k)\) by momentum labels, or orbital
   [`Offset`][qten.geometries.spatials.Offset] labels from which spatial
   inversion about ``inversion_center`` is assembled.
 - ``method="wilson"`` tracks hybrid Wannier charge centers on the six TRIM
@@ -924,7 +991,7 @@ def z2_indices(
         [`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace]
         of diagonal \((k,k)\) blocks whose momenta form a complete 3-D
         reciprocal quotient. The last two axes are square Bloch-Hamiltonian
-        matrices and must span the same Hilbert space up to ray ordering.
+        matrices and are aligned onto a common Hilbert space.
     n_occupied : int | None, optional
         Number of lowest-energy bands defining the occupied subspace. It must
         be even and lie strictly between zero and the total band count.
@@ -935,9 +1002,14 @@ def z2_indices(
         (`RuntimeError`). ``"both"`` requires parity to succeed. Defaults to
         ``"auto"``.
     inversion : Tensor | None, optional
-        Optional rank-3 inversion tensor with the same shape as
-        ``bloch_hamiltonian``. If omitted, spatial inversion is assembled from
-        orbital [`Offset`][qten.geometries.spatials.Offset] labels about
+        Optional rank-3 inversion operator with dims
+        ``(MomentumSpace, HilbertSpace, HilbertSpace)``, or with a diagonal
+        `MomentumBlockSpace` of \((k,k)\) blocks. Band axes are aligned onto
+        the Hamiltonian Hilbert space. Each momentum is paired with
+        \(H(k)\) by its label, not by data-axis order, and the labeled
+        points must form the same complete reciprocal quotient. If omitted,
+        spatial inversion is assembled from orbital
+        [`Offset`][qten.geometries.spatials.Offset] labels about
         ``inversion_center``.
     inversion_center : Offset | Sequence[float] | None, optional
         Fixed point of spatial inversion, as an `Offset` or a 3-vector in the
@@ -962,7 +1034,7 @@ def z2_indices(
 
     Returns
     -------
-    dict[str, Any]
+    Z2ParityResult or Z2WilsonResult or Z2CombinedResult
         Result mapping. Every method returns:
 
         - ``"indices"``: \((\nu_0, \nu_1, \nu_2, \nu_3)\) as integers in
@@ -972,10 +1044,12 @@ def z2_indices(
         For ``method="parity"`` the mapping also contains Fu--Kane
         ``"parity_products"`` at each TRIM, per-TRIM ``"diagnostics"``
         (including a labeled ``"parity_eigenvalues"``
-        [`Tensor`][qten.linalg.tensors.Tensor]), and ``"direct_gap"``.
+        [`Tensor`][qten.linalg.tensors.Tensor] of shape
+        ``(n_occupied,)``), and ``"direct_gap"``.
 
         For ``method="wilson"`` it contains hybrid-Wannier ``"planes"`` whose
-        ``"wcc"``, ``"gap_pos"``, and ``"sweep"`` values are labeled
+        ``"wcc"`` (shape ``(n_perp, n_occupied)``), ``"gap_pos"``, and
+        ``"sweep"`` values are labeled
         [`Tensor`][qten.linalg.tensors.Tensor] objects, per-axis plane
         invariants ``"axis_z2"``, and ``"min_gap"``.
 
@@ -985,14 +1059,18 @@ def z2_indices(
     Raises
     ------
     TypeError
-        If the first tensor dimension is not a momentum space, or either
+        If the Hamiltonian or inversion first dimension is not a
+        `MomentumSpace` or `MomentumBlockSpace`, or either Hamiltonian
         matrix dimension is not a `HilbertSpace`.
     ValueError
         If ``method`` is unsupported; the input is not a rank-3 square Bloch
         Hamiltonian; ``n_occupied`` is invalid; the momentum space is not
         three-dimensional and periodic with a diagonal cell; a
-        `MomentumBlockSpace` contains off-diagonal \((k,k')\) blocks; or
-        momentum points do not form a unique complete reciprocal quotient.
+        `MomentumBlockSpace` contains off-diagonal \((k,k')\) blocks;
+        Hamiltonian or inversion momenta do not form a unique complete
+        reciprocal quotient; inversion band axes do not span the Hamiltonian
+        Hilbert space; or ``n_loop`` / ``n_perp`` are below the Wilson-loop
+        minima.
     RuntimeError
         For ``method="parity"`` or ``method="both"``, if inversion cannot be
         constructed or is not resolved at a TRIM.
@@ -1009,9 +1087,13 @@ def z2_indices(
 
     Notes
     -----
-    The Fu--Kane strong index is the product of the eight TRIM parity products
-    \(\delta(\Gamma_i)\), and each weak index \(\nu_i\) is the product of
-    \(\delta\) over the four TRIM with \(k_i=\pi\).
+    Fu--Kane indices are recovered from TRIM pair-parity products
+    \(\delta(\Gamma_i)\) by \((-1)^{\nu_0}=\prod_i\delta(\Gamma_i)\) and
+    \((-1)^{\nu_j}=\prod_{k_j=\pi}\delta(\Gamma_i)\). Wilson indices use the
+    hybrid-Wannier plane invariants \(\nu(k_j=0)\) and \(\nu(k_j=\pi)\) as
+    described in the module docstring. Both constructions evaluate the
+    Fourier interpolant of the input mesh rather than requiring TRIM or
+    Wilson strings to sit on sampled \(k\)-points.
 
     Examples
     --------

--- a/src/qten/topology/z2.py
+++ b/src/qten/topology/z2.py
@@ -143,6 +143,44 @@ def _unravel_index(index: int, shape: tuple[int, int, int]) -> tuple[int, int, i
     return (i0, i1, i2)
 
 
+def _scatter_to_grid(
+    data: torch.Tensor,
+    momenta: Sequence[Momentum],
+    *,
+    direct_boundary: PeriodicBoundary,
+    dual_boundary: PeriodicBoundary,
+    grid_shape: tuple[int, int, int],
+    canonical_position: dict[tuple[sy.Expr, ...], int],
+) -> torch.Tensor:
+    """Place Bloch matrices onto the rectangular FFT grid by momentum labels."""
+    n_k = math.prod(grid_shape)
+    if len(momenta) != n_k:
+        raise ValueError(
+            f"Found {len(momenta)} momenta, but the lattice shape is {grid_shape}."
+        )
+    grid = data.new_zeros((*grid_shape, data.shape[-2], data.shape[-1]))
+    seen: set[tuple[int, int, int]] = set()
+    for sector, momentum in enumerate(momenta):
+        integer_rep = ImmutableDenseMatrix(direct_boundary.basis.T @ momentum.rep)
+        if any(not sy.sympify(value).is_integer for value in integer_rep):
+            raise ValueError(
+                "Momentum grid contains a point outside the reciprocal quotient."
+            )
+        key = _rep_key(dual_boundary.wrap(integer_rep))
+        if key not in canonical_position:
+            raise ValueError(
+                f"Duplicate or incomplete momentum quotient representative {key}."
+            )
+        index = _unravel_index(canonical_position[key], grid_shape)
+        if index in seen:
+            raise ValueError(f"Duplicate momentum grid point {index}.")
+        seen.add(index)
+        grid[index] = data[sector]
+    if len(seen) != n_k:
+        raise ValueError("Momentum points do not form a complete reciprocal grid.")
+    return grid
+
+
 def _fourier_interpolate(
     hoppings: torch.Tensor,
     k_frac: torch.Tensor | Sequence[float],
@@ -209,9 +247,10 @@ def _kramers_pairs(wcc: torch.Tensor, tolerance: float) -> bool:
         delta[i] = torch.inf
         delta[used] = torch.inf
         partner = int(torch.argmin(delta).item())
-        if not bool(torch.isfinite(delta[partner]).item()) or float(
-            delta[partner].item()
-        ) > tolerance:
+        if (
+            not bool(torch.isfinite(delta[partner]).item())
+            or float(delta[partner].item()) > tolerance
+        ):
             return False
         used[i] = True
         used[partner] = True
@@ -294,9 +333,7 @@ class _Z2Engine:
     inversion_error: Exception | None = None
     time_reversal: torch.Tensor | None = None
 
-    def hamiltonians_at(
-        self, k_frac: torch.Tensor | Sequence[float]
-    ) -> torch.Tensor:
+    def hamiltonians_at(self, k_frac: torch.Tensor | Sequence[float]) -> torch.Tensor:
         ham = _fourier_interpolate(self.hoppings, k_frac, self.rx, self.ry, self.rz)
         return 0.5 * (ham + ham.transpose(-1, -2).conj())
 
@@ -679,9 +716,10 @@ def _build_engine(
             "sheared boundaries are not supported."
         )
     dual_boundary = PeriodicBoundary(ImmutableDenseMatrix(direct_boundary.basis.T))
-    grid_shape = tuple(int(n) for n in lattice.shape)
-    if len(grid_shape) != 3:
+    raw_shape = tuple(int(n) for n in lattice.shape)
+    if len(raw_shape) != 3:
         raise ValueError("A three-dimensional momentum grid is required.")
+    grid_shape = (raw_shape[0], raw_shape[1], raw_shape[2])
     n_k = math.prod(grid_shape)
     if n_k != len(momenta):
         raise ValueError(
@@ -694,27 +732,13 @@ def _build_engine(
     canonical_position = {
         _rep_key(rep): position for position, rep in enumerate(canonical_reps)
     }
-
-    h_grid = data.new_zeros((*grid_shape, n_bands, n_bands))
-    seen: set[tuple[int, int, int]] = set()
-    for sector, momentum in enumerate(momenta):
-        integer_rep = ImmutableDenseMatrix(direct_boundary.basis.T @ momentum.rep)
-        if any(not sy.sympify(value).is_integer for value in integer_rep):
-            raise ValueError(
-                "Momentum grid contains a point outside the reciprocal quotient."
-            )
-        key = _rep_key(dual_boundary.wrap(integer_rep))
-        if key not in canonical_position:
-            raise ValueError(
-                f"Duplicate or incomplete momentum quotient representative {key}."
-            )
-        index = _unravel_index(canonical_position[key], grid_shape)
-        if index in seen:
-            raise ValueError(f"Duplicate momentum grid point {index}.")
-        seen.add(index)
-        h_grid[index] = data[sector]
-    if len(seen) != n_k:
-        raise ValueError("Momentum points do not form a complete reciprocal grid.")
+    scatter_kw = {
+        "direct_boundary": direct_boundary,
+        "dual_boundary": dual_boundary,
+        "grid_shape": grid_shape,
+        "canonical_position": canonical_position,
+    }
+    h_grid = _scatter_to_grid(data, momenta, **scatter_kw)
 
     h_grid = 0.5 * (h_grid + h_grid.transpose(-1, -2).conj())
     hoppings = torch.fft.ifftn(h_grid, dim=(0, 1, 2))
@@ -741,14 +765,11 @@ def _build_engine(
                 "inversion band axes must span the Hamiltonian Hilbert space."
             )
         inversion = inversion.align(-2, row_space).align(-1, row_space)
-        if inversion.data.shape != data.shape:
+        if inversion.data.shape[-2:] != (n_bands, n_bands):
             raise ValueError("inversion must match bloch_hamiltonian's rank and shape.")
-        inv_grid = inversion.data.new_zeros((*grid_shape, n_bands, n_bands))
-        for sector, momentum in enumerate(momenta):
-            integer_rep = ImmutableDenseMatrix(direct_boundary.basis.T @ momentum.rep)
-            key = _rep_key(dual_boundary.wrap(integer_rep))
-            index = _unravel_index(canonical_position[key], grid_shape)
-            inv_grid[index] = inversion.data[sector]
+        inv_grid = _scatter_to_grid(
+            inversion.data, _bloch_momenta(inversion), **scatter_kw
+        )
         inversion_hoppings = torch.fft.ifftn(inv_grid, dim=(0, 1, 2))
     elif isinstance(space, HilbertSpace) and positions_cart is not None:
         if inversion_center is None:

--- a/src/qten/topology/z2.py
+++ b/src/qten/topology/z2.py
@@ -1,13 +1,13 @@
-r"""Three-dimensional \(\mathbb{Z}_2\) invariants of time-reversal-invariant
-insulators.
+r"""Two- and three-dimensional \(\mathbb{Z}_2\) invariants of time-reversal
+invariant insulators.
 
-The occupied subspace of a gapped 3-D Bloch Hamiltonian with even filling
-carries four \(\mathbb{Z}_2\) indices \((\nu_0; \nu_1\nu_2\nu_3)\). This module
-evaluates them from a rank-3
+A gapped 2-D occupied bundle with even filling carries one Kane--Mele index
+\(\nu\). A gapped 3-D bundle carries four Fu--Kane indices
+\((\nu_0; \nu_1\nu_2\nu_3)\). This module evaluates them from a rank-3
 [`Tensor`][qten.linalg.tensors.Tensor] with dims
 ``(MomentumSpace, HilbertSpace, HilbertSpace)`` (or a
 [`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace] of
-diagonal \((k,k)\) blocks whose momenta form a complete 3-D grid).
+diagonal \((k,k)\) blocks whose momenta form a complete 2-D or 3-D grid).
 
 The input mesh is Fourier-interpolated to a tight-binding hopping tensor so
 that time-reversal invariant momenta (TRIM) and Wilson-loop strings can be
@@ -16,13 +16,13 @@ sampled independently of whether those points sit on the original grid.
 Core API
 --------
 - [`z2_indices`][qten.topology.z2_indices]
-  Fu--Kane inversion parities at the eight TRIM, hybrid-Wannier Wilson loops
-  on the six TRIM planes, or both.
+  Fu--Kane inversion parities at the \(2^d\) TRIM, hybrid-Wannier Wilson
+  loops, or both.
 
 Mathematical convention
 -----------------------
-TRIM are the eight points \(\Gamma_i=n/2\) with \(n\in\{0,1\}^3\). At each
-TRIM the occupied inversion eigenvalues \(\xi_n(\Gamma_i)=\pm 1\) come in
+TRIM are the points \(\Gamma_i=n/2\) with \(n\in\{0,1\}^d\). At each TRIM
+the occupied inversion eigenvalues \(\xi_n(\Gamma_i)=\pm 1\) come in
 Kramers pairs. Their pair product is
 
 \[
@@ -30,8 +30,9 @@ Kramers pairs. Their pair product is
 =(-1)^{N_-(\Gamma_i)/2},
 \]
 
-where \(N_-\) is the number of occupied negative parities. The returned
-indices satisfy
+where \(N_-\) is the number of occupied negative parities. In two
+dimensions the returned index satisfies
+\((-1)^\nu=\prod_{i=1}^{4}\delta(\Gamma_i)\). In three dimensions
 
 \[
 (-1)^{\nu_0}=\prod_{i=1}^{8}\delta(\Gamma_i),
@@ -39,9 +40,8 @@ indices satisfy
 (-1)^{\nu_j}=\prod_{\Gamma_i:\,k_j=\pi}\delta(\Gamma_i).
 \]
 
-Without inversion, each TRIM plane \(k_j=0\) or \(k_j=\pi\) carries a 2-D
-\(\mathbb{Z}_2\) invariant from hybrid Wannier charge centers. Along a
-closed string at fixed \(k_\perp\),
+Without inversion, hybrid Wannier charge centers give the same invariants.
+Along a closed string at fixed \(k_\perp\),
 
 \[
 W(k_\perp)=\prod_\ell
@@ -54,7 +54,9 @@ U^\dagger(k_\ell)\,e^{-2\pi i\,\tau\cdot\Delta k}\,U(k_{\ell+1})
 
 where \(U(k)\) holds occupied eigenvectors and \(\tau\) is the orbital
 fractional offset. The plane invariant is the Soluyanov--Vanderbilt
-largest-gap crossing count of those centers. Then
+largest-gap crossing count of those centers. In 2-D that single plane is
+\(\nu\); the two loop orientations should agree. In 3-D each TRIM plane
+\(k_j=0\) or \(k_j=\pi\) carries a 2-D invariant, and
 
 \[
 \nu_0=\nu(k_j=0)+\nu(k_j=\pi)\pmod{2},
@@ -62,7 +64,7 @@ largest-gap crossing count of those centers. Then
 \nu_j=\nu(k_j=\pi).
 \]
 
-If the three axes disagree on \(\nu_0\), the majority vote is returned.
+If the three 3-D axes disagree on \(\nu_0\), the majority vote is returned.
 
 Fourier interpolation
 ---------------------
@@ -89,12 +91,12 @@ The periodic cell must be diagonal in the primitive basis.
 Numerical methods
 -----------------
 - ``method="parity"`` uses Fu--Kane products of inversion eigenvalues at the
-  eight TRIM. It requires an inversion operator: either an explicit rank-3
-  tensor whose matrices are paired to \(H(k)\) by momentum labels, or orbital
+  TRIM. It requires an inversion operator: either an explicit rank-3 tensor
+  whose matrices are paired to \(H(k)\) by momentum labels, or orbital
   [`Offset`][qten.geometries.spatials.Offset] labels from which spatial
   inversion about ``inversion_center`` is assembled.
-- ``method="wilson"`` tracks hybrid Wannier charge centers on the six TRIM
-  planes. It does not need inversion symmetry.
+- ``method="wilson"`` tracks hybrid Wannier charge centers. It does not need
+  inversion symmetry.
 - ``method="auto"`` tries parity first and falls back to Wilson loops if
   inversion cannot be resolved.
 - ``method="both"`` runs both constructions. Parity must succeed; the
@@ -142,10 +144,10 @@ class Z2ParityTrimDiagnostics(TypedDict):
 class Z2ParityResult(TypedDict):
     """Result returned by the Fu--Kane inversion-parity method."""
 
-    indices: tuple[int, int, int, int]
+    indices: tuple[int, ...]
     method: Literal["parity"]
-    parity_products: dict[tuple[int, int, int], int]
-    diagnostics: dict[tuple[int, int, int], Z2ParityTrimDiagnostics]
+    parity_products: dict[tuple[int, ...], int]
+    diagnostics: dict[tuple[int, ...], Z2ParityTrimDiagnostics]
     direct_gap: float
 
 
@@ -163,17 +165,17 @@ class Z2WilsonPlaneResult(TypedDict):
 class Z2WilsonResult(TypedDict):
     """Result returned by the Wilson-loop method."""
 
-    indices: tuple[int, int, int, int]
+    indices: tuple[int, ...]
     method: Literal["wilson"]
     planes: dict[tuple[int, float], Z2WilsonPlaneResult]
-    axis_z2: tuple[tuple[int, int], tuple[int, int], tuple[int, int]]
+    axis_z2: tuple[tuple[int, ...], ...]
     min_gap: float
 
 
 class Z2CombinedResult(TypedDict):
     """Result returned when both parity and Wilson-loop methods are run."""
 
-    indices: tuple[int, int, int, int]
+    indices: tuple[int, ...]
     method: Literal["both"]
     parity: Z2ParityResult
     wilson: Z2WilsonResult
@@ -202,12 +204,13 @@ def _bloch_momenta(bloch_hamiltonian: Tensor) -> tuple[Momentum, ...]:
     )
 
 
-def _unravel_index(index: int, shape: tuple[int, int, int]) -> tuple[int, int, int]:
-    _, n1, n2 = shape
-    i2 = index % n2
-    i1 = (index // n2) % n1
-    i0 = index // (n1 * n2)
-    return (i0, i1, i2)
+def _unravel_index(index: int, shape: tuple[int, ...]) -> tuple[int, ...]:
+    coords = [0] * len(shape)
+    remainder = int(index)
+    for i in range(len(shape) - 1, -1, -1):
+        coords[i] = remainder % shape[i]
+        remainder //= shape[i]
+    return tuple(coords)
 
 
 def _scatter_to_grid(
@@ -216,7 +219,7 @@ def _scatter_to_grid(
     *,
     direct_boundary: PeriodicBoundary,
     dual_boundary: PeriodicBoundary,
-    grid_shape: tuple[int, int, int],
+    grid_shape: tuple[int, ...],
     canonical_position: dict[tuple[sy.Expr, ...], int],
 ) -> torch.Tensor:
     """Place Bloch matrices onto the rectangular FFT grid by momentum labels."""
@@ -226,7 +229,7 @@ def _scatter_to_grid(
             f"Found {len(momenta)} momenta, but the lattice shape is {grid_shape}."
         )
     grid = data.new_zeros((*grid_shape, data.shape[-2], data.shape[-1]))
-    seen: set[tuple[int, int, int]] = set()
+    seen: set[tuple[int, ...]] = set()
     for sector, momentum in enumerate(momenta):
         integer_rep = ImmutableDenseMatrix(direct_boundary.basis.T @ momentum.rep)
         if any(not sy.sympify(value).is_integer for value in integer_rep):
@@ -251,30 +254,37 @@ def _scatter_to_grid(
 def _fourier_interpolate(
     hoppings: torch.Tensor,
     k_frac: torch.Tensor | Sequence[float],
-    rx: torch.Tensor,
-    ry: torch.Tensor,
-    rz: torch.Tensor,
+    r_axes: tuple[torch.Tensor, ...],
 ) -> torch.Tensor:
+    dim = len(r_axes)
     real_dtype = hoppings.real.dtype
     k_frac = torch.as_tensor(k_frac, device=hoppings.device, dtype=real_dtype)
     batched = k_frac.ndim == 2
     if not batched:
         k_frac = k_frac[None, :]
+    if k_frac.shape[-1] != dim:
+        raise ValueError(f"k_frac must have {dim} components.")
     phase = hoppings.new_tensor(-2j * math.pi)
-    px = torch.exp(phase * k_frac[:, 0, None] * rx[None, :])
-    py = torch.exp(phase * k_frac[:, 1, None] * ry[None, :])
-    pz = torch.exp(phase * k_frac[:, 2, None] * rz[None, :])
-    values = torch.einsum("xyzab,kx,ky,kz->kab", hoppings, px, py, pz)
+    letters = "xyz"[:dim]
+    spatial = "".join(letters)
+    phase_ids = ",".join(f"k{axis}" for axis in letters)
+    phases = [
+        torch.exp(phase * k_frac[:, i, None] * r_axes[i][None, :]) for i in range(dim)
+    ]
+    values = torch.einsum(f"{spatial}ab,{phase_ids}->kab", hoppings, *phases)
     return values if batched else values[0]
 
 
 def _indices_from_deltas(
-    parity_products: dict[tuple[int, int, int], int],
-) -> tuple[int, int, int, int]:
+    parity_products: dict[tuple[int, ...], int],
+    dim: int,
+) -> tuple[int, ...]:
     strong = math.prod(parity_products.values())
+    if dim == 2:
+        return (int(strong < 0),)
     weak = tuple(
         math.prod(delta for bits, delta in parity_products.items() if bits[axis] == 1)
-        for axis in range(3)
+        for axis in range(dim)
     )
     return (int(strong < 0), *(int(product < 0) for product in weak))
 
@@ -361,10 +371,14 @@ def _time_reversal_matrix(
     return theta
 
 
-def _inversion_element():
+def _inversion_element(dim: int):
+    if dim == 2:
+        # In 2-D, r -> -r is a pi rotation. Use a trivial spin lift so the
+        # operator is spatial inversion, not a spinful C2.
+        return pointgroup("c2-xy:xy", spin="trivial")
     for element in pointgroup("-1").elements():
-        dim = element.irrep.rows
-        if sy.simplify(element.irrep + sy.eye(dim)) == sy.zeros(dim):
+        irrep_dim = element.irrep.rows
+        if sy.simplify(element.irrep + sy.eye(irrep_dim)) == sy.zeros(irrep_dim):
             return element
     raise RuntimeError("Point group -1 does not contain spatial inversion.")
 
@@ -386,9 +400,7 @@ def _as_inversion_center(
 @dataclass
 class _Z2Engine:
     hoppings: torch.Tensor
-    rx: torch.Tensor
-    ry: torch.Tensor
-    rz: torch.Tensor
+    r_axes: tuple[torch.Tensor, ...]
     tau: torch.Tensor
     n_occupied: int
     n_bands: int
@@ -400,14 +412,18 @@ class _Z2Engine:
     inversion_error: Exception | None = None
     time_reversal: torch.Tensor | None = None
 
+    @property
+    def dim(self) -> int:
+        return len(self.r_axes)
+
     def hamiltonians_at(self, k_frac: torch.Tensor | Sequence[float]) -> torch.Tensor:
-        ham = _fourier_interpolate(self.hoppings, k_frac, self.rx, self.ry, self.rz)
+        ham = _fourier_interpolate(self.hoppings, k_frac, self.r_axes)
         return 0.5 * (ham + ham.transpose(-1, -2).conj())
 
     def inversion_at_trim(self, trim_frac: torch.Tensor) -> torch.Tensor:
         if self.inversion_hoppings is not None:
             return _fourier_interpolate(
-                self.inversion_hoppings, trim_frac, self.rx, self.ry, self.rz
+                self.inversion_hoppings, trim_frac, self.r_axes
             )
         if (
             self.inversion_i0 is None
@@ -449,11 +465,11 @@ class _Z2Engine:
         )
 
     def run_parity(self, parity_tolerance: float) -> Z2ParityResult:
-        parity_products: dict[tuple[int, int, int], int] = {}
-        diagnostics: dict[tuple[int, int, int], Z2ParityTrimDiagnostics] = {}
+        parity_products: dict[tuple[int, ...], int] = {}
+        diagnostics: dict[tuple[int, ...], Z2ParityTrimDiagnostics] = {}
         real_dtype = self.hoppings.real.dtype
         device = self.hoppings.device
-        for bits in product((0, 1), repeat=3):
+        for bits in product((0, 1), repeat=self.dim):
             k_frac = torch.tensor(bits, dtype=real_dtype, device=device) / 2
             ham = self.hamiltonians_at(k_frac)
             inv_matrix = self.inversion_at_trim(k_frac)
@@ -504,7 +520,7 @@ class _Z2Engine:
         finite_gaps = [gap for gap in gaps if math.isfinite(gap)]
         direct_gap = min(finite_gaps) if finite_gaps else float("nan")
         return {
-            "indices": _indices_from_deltas(parity_products),
+            "indices": _indices_from_deltas(parity_products, self.dim),
             "method": "parity",
             "parity_products": parity_products,
             "diagnostics": diagnostics,
@@ -537,7 +553,7 @@ class _Z2Engine:
             min_gap = float("nan")
         n_pts = occupied.shape[0]
         wilson = None
-        dk = occupied.new_zeros(3, dtype=self.tau.dtype)
+        dk = occupied.new_zeros(self.dim, dtype=self.tau.dtype)
         dk[loop_axis] = 1.0 / n_pts
         for i in range(n_pts):
             step = self._unitary_overlap(occupied[i], occupied[(i + 1) % n_pts], dk)
@@ -549,14 +565,14 @@ class _Z2Engine:
 
     def _plane_z2(
         self,
-        normal: int,
-        trim_value: float,
+        loop_axis: int,
+        sweep_axis: int,
         n_loop: int,
         n_perp: int,
         kramers_tolerance: float,
+        *,
+        fixed: dict[int, float] | None = None,
     ) -> Z2WilsonPlaneResult:
-        loop_axis = (normal + 1) % 3
-        sweep_axis = (normal + 2) % 3
         real_dtype = self.hoppings.real.dtype
         device = self.hoppings.device
         sweep = torch.linspace(0.0, 0.5, n_perp, dtype=real_dtype, device=device)
@@ -564,8 +580,10 @@ class _Z2Engine:
         wcc_list: list[torch.Tensor] = []
         min_gap = math.inf
         for ky in sweep:
-            k_string = torch.zeros((n_loop, 3), dtype=real_dtype, device=device)
-            k_string[:, normal] = trim_value
+            k_string = torch.zeros((n_loop, self.dim), dtype=real_dtype, device=device)
+            if fixed:
+                for axis, value in fixed.items():
+                    k_string[:, axis] = value
             k_string[:, sweep_axis] = ky
             k_string[:, loop_axis] = loop
             wcc, gap = self._wilson_wcc(k_string, loop_axis)
@@ -601,34 +619,69 @@ class _Z2Engine:
         if n_loop < 8 or n_perp < 5:
             raise ValueError("n_loop must be >= 8 and n_perp must be >= 5.")
         planes: dict[tuple[int, float], Z2WilsonPlaneResult] = {}
-        axis_z2 = []
-        for normal in range(3):
-            zero = self._plane_z2(normal, 0.0, n_loop, n_perp, kramers_tolerance)
-            pi = self._plane_z2(normal, 0.5, n_loop, n_perp, kramers_tolerance)
-            planes[(normal, 0.0)] = zero
-            planes[(normal, 0.5)] = pi
-            axis_z2.append((zero["z2"], pi["z2"]))
-        strong = [int((z0 + zpi) % 2) for z0, zpi in axis_z2]
-        if len(set(strong)) == 1:
-            strong_index = strong[0]
+        axis_z2: list[tuple[int, ...]] = []
+        if self.dim == 2:
+            for loop_axis in range(2):
+                sweep_axis = 1 - loop_axis
+                plane = self._plane_z2(
+                    loop_axis, sweep_axis, n_loop, n_perp, kramers_tolerance
+                )
+                planes[(loop_axis, 0.0)] = plane
+                axis_z2.append((plane["z2"],))
+            values = [item[0] for item in axis_z2]
+            if len(set(values)) == 1:
+                indices: tuple[int, ...] = (values[0],)
+            else:
+                warnings.warn(
+                    "Two-dimensional Wilson-loop orientations disagree: "
+                    f"{values}. Increase n_loop / n_perp.",
+                    RuntimeWarning,
+                    stacklevel=3,
+                )
+                indices = (values[0],)
         else:
-            strong_index = int(sum(strong) >= 2)
-        indices = (strong_index, axis_z2[0][1], axis_z2[1][1], axis_z2[2][1])
+            for normal in range(self.dim):
+                loop_axis = (normal + 1) % self.dim
+                sweep_axis = (normal + 2) % self.dim
+                zero = self._plane_z2(
+                    loop_axis,
+                    sweep_axis,
+                    n_loop,
+                    n_perp,
+                    kramers_tolerance,
+                    fixed={normal: 0.0},
+                )
+                pi = self._plane_z2(
+                    loop_axis,
+                    sweep_axis,
+                    n_loop,
+                    n_perp,
+                    kramers_tolerance,
+                    fixed={normal: 0.5},
+                )
+                planes[(normal, 0.0)] = zero
+                planes[(normal, 0.5)] = pi
+                axis_z2.append((zero["z2"], pi["z2"]))
+            strong = [int((z0 + zpi) % 2) for z0, zpi in axis_z2]
+            if len(set(strong)) == 1:
+                strong_index = strong[0]
+            else:
+                strong_index = int(sum(strong) >= 2)
+                warnings.warn(
+                    "Strong-index estimates from the three Wilson-loop axes disagree: "
+                    f"{strong}. Increase n_loop / n_perp.",
+                    RuntimeWarning,
+                    stacklevel=3,
+                )
+            indices = (strong_index, axis_z2[0][1], axis_z2[1][1], axis_z2[2][1])
         min_gap = min(plane["min_gap"] for plane in planes.values())
         result: Z2WilsonResult = {
             "indices": indices,
             "method": "wilson",
             "planes": planes,
-            "axis_z2": (axis_z2[0], axis_z2[1], axis_z2[2]),
+            "axis_z2": tuple(axis_z2),
             "min_gap": min_gap,
         }
-        if len(set(strong)) != 1:
-            warnings.warn(
-                "Strong-index estimates from the three Wilson-loop axes disagree: "
-                f"{strong}. Increase n_loop / n_perp.",
-                RuntimeWarning,
-                stacklevel=3,
-            )
         unresolved = [
             key for key, plane in planes.items() if not plane["kramers_resolved"]
         ]
@@ -642,7 +695,7 @@ class _Z2Engine:
         return result
 
     def check_time_reversal(self, *, stacklevel: int = 3) -> None:
-        origin = self.hoppings.new_zeros(3, dtype=self.hoppings.real.dtype)
+        origin = self.hoppings.new_zeros(self.dim, dtype=self.hoppings.real.dtype)
         energies = torch.linalg.eigvalsh(self.hamiltonians_at(origin))
         span = float((energies.max() - energies.min()).clamp_min(1.0).item())
         pair_tol = max(1e-6, 1e-4 * span)
@@ -656,8 +709,9 @@ class _Z2Engine:
             )
         if self.time_reversal is None:
             return
+        sample_frac = [0.2, 0.3, 0.1][: self.dim]
         sample = torch.tensor(
-            [0.2, 0.3, 0.1],
+            sample_frac,
             dtype=self.hoppings.real.dtype,
             device=self.hoppings.device,
         )
@@ -685,7 +739,7 @@ def _orbital_geometry(
     device: torch.device,
     dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
-    tau = torch.zeros((n_bands, 3), dtype=dtype, device=device)
+    tau = torch.zeros((n_bands, lattice.dim), dtype=dtype, device=device)
     if not isinstance(space, HilbertSpace):
         return tau, None
     states = list(space.elements())
@@ -714,7 +768,7 @@ def _orbital_geometry(
             dtype=torch.float64,
         )
         rebased = offset.rebase(lattice)
-        for j in range(3):
+        for j in range(lattice.dim):
             tau[index, j] = float(rebased.rep[j])
     if any(item is None for item in positions):
         raise RuntimeError("Offset labels do not cover every orbital index.")
@@ -726,7 +780,7 @@ def _spatial_inversion_matrix(
     center: Offset,
     hoppings: torch.Tensor,
 ) -> torch.Tensor:
-    inv_op = PointGroupOpr(_inversion_element()).fixpoint_at(center)
+    inv_op = PointGroupOpr(_inversion_element(center.space.dim)).fixpoint_at(center)
     if contains_spin(space):
         matrix = spinful_hilbert_opr_repr(inv_op, space)
     else:
@@ -759,8 +813,11 @@ def _build_engine(
     n_bands = int(data.shape[-1])
 
     momenta = _bloch_momenta(bloch_hamiltonian)
-    if not momenta or len(momenta[0].rep) != 3:
-        raise ValueError("A three-dimensional momentum grid is required.")
+    if not momenta:
+        raise ValueError("The momentum grid must not be empty.")
+    momentum_dim = len(momenta[0].rep)
+    if momentum_dim not in (2, 3):
+        raise ValueError("A two- or three-dimensional momentum grid is required.")
 
     if n_occupied is None:
         n_occupied = n_bands // 2
@@ -783,10 +840,9 @@ def _build_engine(
             "sheared boundaries are not supported."
         )
     dual_boundary = PeriodicBoundary(ImmutableDenseMatrix(direct_boundary.basis.T))
-    raw_shape = tuple(int(n) for n in lattice.shape)
-    if len(raw_shape) != 3:
-        raise ValueError("A three-dimensional momentum grid is required.")
-    grid_shape = (raw_shape[0], raw_shape[1], raw_shape[2])
+    grid_shape = tuple(int(n) for n in lattice.shape)
+    if len(grid_shape) != momentum_dim:
+        raise ValueError("A two- or three-dimensional momentum grid is required.")
     n_k = math.prod(grid_shape)
     if n_k != len(momenta):
         raise ValueError(
@@ -808,12 +864,13 @@ def _build_engine(
     h_grid = _scatter_to_grid(data, momenta, **scatter_kw)
 
     h_grid = 0.5 * (h_grid + h_grid.transpose(-1, -2).conj())
-    hoppings = torch.fft.ifftn(h_grid, dim=(0, 1, 2))
+    hoppings = torch.fft.ifftn(h_grid, dim=tuple(range(momentum_dim)))
     device = hoppings.device
     real_dtype = hoppings.real.dtype
-    rx = (torch.fft.fftfreq(grid_shape[0], dtype=real_dtype) * grid_shape[0]).to(device)
-    ry = (torch.fft.fftfreq(grid_shape[1], dtype=real_dtype) * grid_shape[1]).to(device)
-    rz = (torch.fft.fftfreq(grid_shape[2], dtype=real_dtype) * grid_shape[2]).to(device)
+    r_axes = tuple(
+        (torch.fft.fftfreq(size, dtype=real_dtype) * size).to(device)
+        for size in grid_shape
+    )
 
     space = bloch_hamiltonian.dims[1]
     tau, positions_cart = _orbital_geometry(space, lattice, n_bands, device, real_dtype)
@@ -837,20 +894,20 @@ def _build_engine(
         inv_grid = _scatter_to_grid(
             inversion.data, _bloch_momenta(inversion), **scatter_kw
         )
-        inversion_hoppings = torch.fft.ifftn(inv_grid, dim=(0, 1, 2))
+        inversion_hoppings = torch.fft.ifftn(inv_grid, dim=tuple(range(momentum_dim)))
     elif isinstance(space, HilbertSpace) and positions_cart is not None:
         if inversion_center is None:
             unique_reps: list[tuple[sy.Expr, ...]] = []
             for state in space.elements():
                 frac = state.irrep_of(Offset).rebase(lattice).fractional()
-                rep = tuple(sy.simplify(frac.rep[j]) for j in range(3))
+                rep = tuple(sy.simplify(frac.rep[j]) for j in range(lattice.dim))
                 if rep not in unique_reps:
                     unique_reps.append(rep)
             n_sites = len(unique_reps)
             center_rep = sy.Matrix(
                 [
                     sy.simplify(sum(rep[j] for rep in unique_reps) / n_sites)
-                    for j in range(3)
+                    for j in range(lattice.dim)
                 ]
             )
             center = Offset(rep=ImmutableDenseMatrix(center_rep), space=lattice)
@@ -868,9 +925,7 @@ def _build_engine(
 
     return _Z2Engine(
         hoppings=hoppings,
-        rx=rx,
-        ry=ry,
-        rz=rz,
+        r_axes=r_axes,
         tau=tau,
         n_occupied=n_occupied,
         n_bands=n_bands,
@@ -963,24 +1018,26 @@ def z2_indices(
     kramers_tolerance: float = 0.08,
     gap_tolerance: float = 1e-8,
 ) -> Z2ParityResult | Z2WilsonResult | Z2CombinedResult:
-    r"""Compute the 3-D \(\mathbb{Z}_2\) indices of an occupied band subspace.
+    r"""Compute the 2-D or 3-D \(\mathbb{Z}_2\) indices of an occupied band
+    subspace.
 
     The ``n_occupied`` lowest-energy eigenstates, which must form an even
     number of Kramers pairs, define an occupied bundle over a complete
-    three-dimensional periodic momentum grid. Two numerical methods are
-    available:
+    two- or three-dimensional periodic momentum grid. Two numerical methods
+    are available:
 
-    - ``method="parity"`` evaluates Fu--Kane inversion eigenvalues at the eight
-      TRIM and returns \((\nu_0; \nu_1\nu_2\nu_3)\) from their products.
-    - ``method="wilson"`` computes hybrid Wannier charge centers on the six
-      TRIM planes \(k_i=0\) and \(k_i=1/2\). The strong index is
-      \(\nu_0=\nu(k_i=0)+\nu(k_i=\pi)\bmod 2\) and the weak indices are the
+    - ``method="parity"`` evaluates Fu--Kane inversion eigenvalues at the
+      \(2^d\) TRIM. Two dimensions return \((\nu,)\); three dimensions return
+      \((\nu_0; \nu_1\nu_2\nu_3)\).
+    - ``method="wilson"`` computes hybrid Wannier charge centers. In 2-D the
+      two loop orientations should agree on \(\nu\). In 3-D the strong index
+      is \(\nu_0=\nu(k_i=0)+\nu(k_i=\pi)\bmod 2\) and the weak indices are the
       three \(k_i=\pi\) plane invariants. If the three axes disagree on
       \(\nu_0\), the majority vote is returned.
 
     The Hamiltonian is Fourier-interpolated from the supplied mesh, so TRIM
     and Wilson strings need not coincide with sampled \(k\)-points. This is
-    the construction used for odd diamond meshes such as \(27^3\). The
+    the construction used for odd meshes such as \(27^3\) or \(9^2\). The
     periodic cell must be diagonal in the primitive basis.
 
     Parameters
@@ -989,7 +1046,7 @@ def z2_indices(
         Rank-3 Hermitian [`Tensor`][qten.linalg.tensors.Tensor] with dims
         ``(MomentumSpace, HilbertSpace, HilbertSpace)``, or with a
         [`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace]
-        of diagonal \((k,k)\) blocks whose momenta form a complete 3-D
+        of diagonal \((k,k)\) blocks whose momenta form a complete 2-D or 3-D
         reciprocal quotient. The last two axes are square Bloch-Hamiltonian
         matrices and are aligned onto a common Hilbert space.
     n_occupied : int | None, optional
@@ -1012,9 +1069,9 @@ def z2_indices(
         [`Offset`][qten.geometries.spatials.Offset] labels about
         ``inversion_center``.
     inversion_center : Offset | Sequence[float] | None, optional
-        Fixed point of spatial inversion, as an `Offset` or a 3-vector in the
-        Hamiltonian's direct-lattice coordinates. Defaults to the centroid of
-        the unique orbital offsets.
+        Fixed point of spatial inversion, as an `Offset` or a \(d\)-vector in
+        the Hamiltonian's direct-lattice coordinates. Defaults to the centroid
+        of the unique orbital offsets.
     n_loop : int, optional
         Number of Wilson-loop samples around each closed \(k\)-string.
         Must be at least 8 when Wilson loops are evaluated. Defaults to 32.
@@ -1037,8 +1094,8 @@ def z2_indices(
     Z2ParityResult or Z2WilsonResult or Z2CombinedResult
         Result mapping. Every method returns:
 
-        - ``"indices"``: \((\nu_0, \nu_1, \nu_2, \nu_3)\) as integers in
-          \(\{0,1\}\).
+        - ``"indices"``: \((\nu,)\) in 2-D or \((\nu_0, \nu_1, \nu_2, \nu_3)\)
+          in 3-D, as integers in \(\{0,1\}\).
         - ``"method"``: the construction that produced those indices.
 
         For ``method="parity"`` the mapping also contains Fu--Kane
@@ -1065,7 +1122,7 @@ def z2_indices(
     ValueError
         If ``method`` is unsupported; the input is not a rank-3 square Bloch
         Hamiltonian; ``n_occupied`` is invalid; the momentum space is not
-        three-dimensional and periodic with a diagonal cell; a
+        two- or three-dimensional and periodic with a diagonal cell; a
         `MomentumBlockSpace` contains off-diagonal \((k,k')\) blocks;
         Hamiltonian or inversion momenta do not form a unique complete
         reciprocal quotient; inversion band axes do not span the Hamiltonian
@@ -1080,20 +1137,19 @@ def z2_indices(
     RuntimeWarning
         If the sampled minimum direct gap is no larger than ``gap_tolerance``;
         if ``method="auto"`` falls back from parity to Wilson loops; if the
-        three Wilson axes disagree on \(\nu_0\) (majority vote is used); if
-        Kramers pairing of Wannier centers is unresolved; if parity and
-        Wilson indices disagree; or if the sampled spectrum is not
-        time-reversal / Kramers consistent.
+        two 2-D Wilson orientations disagree; if the three 3-D Wilson axes
+        disagree on \(\nu_0\) (majority vote is used); if Kramers pairing of
+        Wannier centers is unresolved; if parity and Wilson indices disagree;
+        or if the sampled spectrum is not time-reversal / Kramers consistent.
 
     Notes
     -----
-    Fu--Kane indices are recovered from TRIM pair-parity products
-    \(\delta(\Gamma_i)\) by \((-1)^{\nu_0}=\prod_i\delta(\Gamma_i)\) and
+    In 2-D, Fu--Kane gives \((-1)^\nu=\prod_i\delta(\Gamma_i)\). In 3-D,
+    \((-1)^{\nu_0}=\prod_i\delta(\Gamma_i)\) and
     \((-1)^{\nu_j}=\prod_{k_j=\pi}\delta(\Gamma_i)\). Wilson indices use the
-    hybrid-Wannier plane invariants \(\nu(k_j=0)\) and \(\nu(k_j=\pi)\) as
-    described in the module docstring. Both constructions evaluate the
-    Fourier interpolant of the input mesh rather than requiring TRIM or
-    Wilson strings to sit on sampled \(k\)-points.
+    hybrid-Wannier plane invariants described in the module docstring. Both
+    constructions evaluate the Fourier interpolant of the input mesh rather
+    than requiring TRIM or Wilson strings to sit on sampled \(k\)-points.
 
     Examples
     --------
@@ -1101,7 +1157,7 @@ def z2_indices(
 
     ```python
     result = z2_indices(hamiltonian, n_occupied=2, inversion=inversion, method="parity")
-    nu0, nu1, nu2, nu3 = result["indices"]
+    indices = result["indices"]
     ```
 
     Fall back to Wilson loops on a system without inversion:

--- a/src/qten/topology/z2.py
+++ b/src/qten/topology/z2.py
@@ -6,8 +6,8 @@ carries four \(\mathbb{Z}_2\) indices \((\nu_0; \nu_1\nu_2\nu_3)\). This module
 evaluates them from a rank-3
 [`Tensor`][qten.linalg.tensors.Tensor] with dims
 ``(MomentumSpace, HilbertSpace, HilbertSpace)`` (or a
-[`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace] whose
-left momenta form a complete 3-D grid).
+[`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace] of
+diagonal \((k,k)\) blocks whose momenta form a complete 3-D grid).
 
 The input mesh is Fourier-interpolated to a tight-binding hopping tensor so
 that time-reversal invariant momenta (TRIM) and Wilson-loop strings can be
@@ -28,9 +28,10 @@ Numerical methods
   inversion about ``inversion_center`` is assembled.
 - ``method="wilson"`` tracks hybrid Wannier charge centers on the six TRIM
   planes. It does not need inversion symmetry.
-- ``method="auto"`` tries parity first and falls back to Wilson loops.
-- ``method="both"`` runs both constructions. The returned indices are the
-  parity values when that method succeeds.
+- ``method="auto"`` tries parity first and falls back to Wilson loops if
+  inversion cannot be resolved.
+- ``method="both"`` runs both constructions. Parity must succeed; the
+  returned indices are the parity values.
 """
 
 from __future__ import annotations
@@ -42,25 +43,31 @@ from typing import Literal, overload, TypedDict
 import math
 import warnings
 
-import numpy as np
 import sympy as sy
 import torch
 from sympy import ImmutableDenseMatrix
 
-from ..geometries import Momentum, Offset, PeriodicBoundary, ReciprocalLattice
+from ..geometries import Lattice, Momentum, Offset, PeriodicBoundary, ReciprocalLattice
 from ..linalg.tensors import Tensor
-from ..phys import Spin
+from ..phys import Spin, as_spin, contains_spin
 from ..pointgroups import pointgroup
 from ..pointgroups.elements import PointGroupOpr
 from ..pointgroups.ops import spinful_hilbert_opr_repr
-from ..symbolics import HilbertSpace, MomentumBlockSpace, MomentumSpace
+from ..symbolics import (
+    HilbertSpace,
+    IndexSpace,
+    MomentumBlockSpace,
+    MomentumSpace,
+    hilbert_opr_repr,
+    same_rays,
+)
 
 
 class Z2ParityTrimDiagnostics(TypedDict):
     """Inversion-parity diagnostics at one TRIM."""
 
     delta: int
-    parity_eigenvalues: np.ndarray
+    parity_eigenvalues: Tensor
     commutator_error: float
     direct_gap: float
 
@@ -79,9 +86,9 @@ class Z2WilsonPlaneResult(TypedDict):
     """Hybrid-Wannier data on one TRIM plane."""
 
     z2: int
-    wcc: np.ndarray
-    gap_pos: np.ndarray
-    sweep: np.ndarray
+    wcc: Tensor
+    gap_pos: Tensor
+    sweep: Tensor
     min_gap: float
     kramers_resolved: bool
 
@@ -112,21 +119,33 @@ def _rep_key(rep: ImmutableDenseMatrix) -> tuple[sy.Expr, ...]:
 def _bloch_momenta(bloch_hamiltonian: Tensor) -> tuple[Momentum, ...]:
     k_dim = bloch_hamiltonian.dims[0]
     if isinstance(k_dim, MomentumSpace):
-        momenta = tuple(k_dim.elements())
-    elif isinstance(k_dim, MomentumBlockSpace):
-        momenta = tuple(pair[0] for pair in k_dim.elements())
-    else:
-        raise TypeError(
-            "The first dimension must be a MomentumSpace or MomentumBlockSpace."
-        )
-    if momenta and isinstance(momenta[0], tuple):
-        momenta = tuple(pair[0] for pair in momenta)
-    return momenta
+        return tuple(k_dim.elements())
+    if isinstance(k_dim, MomentumBlockSpace):
+        momenta: list[Momentum] = []
+        for left, right in k_dim.elements():
+            if left != right:
+                raise ValueError(
+                    "Z2 requires a diagonal momentum-block Hamiltonian "
+                    "(left and right momenta equal at every block)."
+                )
+            momenta.append(left)
+        return tuple(momenta)
+    raise TypeError(
+        "The first dimension must be a MomentumSpace or MomentumBlockSpace."
+    )
+
+
+def _unravel_index(index: int, shape: tuple[int, int, int]) -> tuple[int, int, int]:
+    _, n1, n2 = shape
+    i2 = index % n2
+    i1 = (index // n2) % n1
+    i0 = index // (n1 * n2)
+    return (i0, i1, i2)
 
 
 def _fourier_interpolate(
     hoppings: torch.Tensor,
-    k_frac: torch.Tensor | np.ndarray | Sequence[float],
+    k_frac: torch.Tensor | Sequence[float],
     rx: torch.Tensor,
     ry: torch.Tensor,
     rz: torch.Tensor,
@@ -155,12 +174,13 @@ def _indices_from_deltas(
     return (int(strong < 0), *(int(product < 0) for product in weak))
 
 
-def _largest_gap_position(wcc: np.ndarray) -> float:
-    wcc = np.sort(np.asarray(wcc, dtype=float) % 1.0)
-    extended = np.concatenate([wcc, [wcc[0] + 1.0]])
-    gaps = np.diff(extended)
-    index = int(np.argmax(gaps))
-    return float((extended[index] + 0.5 * gaps[index]) % 1.0)
+def _largest_gap_position(wcc: torch.Tensor) -> float:
+    wcc = wcc.real % 1.0
+    wcc, _ = torch.sort(wcc)
+    extended = torch.cat((wcc, wcc[:1] + 1.0))
+    gaps = extended[1:] - extended[:-1]
+    index = int(torch.argmax(gaps).item())
+    return float(((extended[index] + 0.5 * gaps[index]) % 1.0).item())
 
 
 def _sgng(gap_left: float, gap_right: float, wcc_pos: float) -> int:
@@ -175,24 +195,64 @@ def _sgng(gap_left: float, gap_right: float, wcc_pos: float) -> int:
     return -1 if crossed else 1
 
 
-def _kramers_pairs(wcc: np.ndarray, tolerance: float) -> bool:
-    wcc = np.sort(np.asarray(wcc, dtype=float) % 1.0)
-    n = len(wcc)
+def _kramers_pairs(wcc: torch.Tensor, tolerance: float) -> bool:
+    wcc, _ = torch.sort(wcc.real % 1.0)
+    n = int(wcc.numel())
     if n % 2:
         return False
-    used = np.zeros(n, dtype=bool)
+    used = torch.zeros(n, dtype=torch.bool, device=wcc.device)
     for i in range(n):
-        if used[i]:
+        if bool(used[i].item()):
             continue
-        delta = np.minimum((wcc - wcc[i]) % 1.0, (wcc[i] - wcc) % 1.0)
-        delta[i] = np.inf
-        delta[used] = np.inf
-        partner = int(np.argmin(delta))
-        if not np.isfinite(delta[partner]) or delta[partner] > tolerance:
+        delta = torch.minimum((wcc - wcc[i]) % 1.0, (wcc[i] - wcc) % 1.0)
+        delta = delta.clone()
+        delta[i] = torch.inf
+        delta[used] = torch.inf
+        partner = int(torch.argmin(delta).item())
+        if not bool(torch.isfinite(delta[partner]).item()) or float(
+            delta[partner].item()
+        ) > tolerance:
             return False
         used[i] = True
         used[partner] = True
     return True
+
+
+def _kramers_spectrum(energies: torch.Tensor, tolerance: float) -> bool:
+    values, _ = torch.sort(energies.real)
+    if int(values.numel()) % 2:
+        return False
+    pairs = values.reshape(-1, 2)
+    return bool((pairs[:, 1] - pairs[:, 0]).max().item() <= tolerance)
+
+
+def _time_reversal_matrix(
+    space: HilbertSpace, like: torch.Tensor
+) -> torch.Tensor | None:
+    if not contains_spin(space):
+        return None
+    theta = like.new_zeros((space.dim, space.dim))
+    index_of: dict[tuple[tuple[object, ...], object], int] = {}
+    parsed: list[tuple[tuple[object, ...], object, int]] = []
+    for psi in space.elements():
+        try:
+            spin = psi.irrep_of(Spin)
+        except ValueError:
+            return None
+        spin = as_spin(spin)
+        if spin is None:
+            return None
+        nons = tuple(rep for rep in psi.base if as_spin(rep) is None)
+        index = space.structure[psi]
+        index_of[(nons, spin)] = index
+        parsed.append((nons, spin, index))
+    for nons, spin, index in parsed:
+        partner = Spin.down if spin.is_up else Spin.up
+        other = index_of.get((nons, partner))
+        if other is None:
+            return None
+        theta[other, index] = 1.0 if spin.is_up else -1.0
+    return theta
 
 
 def _inversion_element():
@@ -226,14 +286,16 @@ class _Z2Engine:
     tau: torch.Tensor
     n_occupied: int
     n_bands: int
-    lattice: object
+    lattice: Lattice
     inversion_hoppings: torch.Tensor | None
     inversion_i0: torch.Tensor | None
     inversion_center_vec: torch.Tensor | None
     positions_cart: torch.Tensor | None
+    inversion_error: Exception | None = None
+    time_reversal: torch.Tensor | None = None
 
     def hamiltonians_at(
-        self, k_frac: torch.Tensor | np.ndarray | Sequence[float]
+        self, k_frac: torch.Tensor | Sequence[float]
     ) -> torch.Tensor:
         ham = _fourier_interpolate(self.hoppings, k_frac, self.rx, self.ry, self.rz)
         return 0.5 * (ham + ham.transpose(-1, -2).conj())
@@ -248,6 +310,11 @@ class _Z2Engine:
             or self.inversion_center_vec is None
             or self.positions_cart is None
         ):
+            if self.inversion_error is not None:
+                raise RuntimeError(
+                    "Cannot build inversion from orbital Offset labels: "
+                    f"{self.inversion_error}"
+                ) from self.inversion_error
             raise RuntimeError(
                 "Cannot build inversion without Offset-labeled orbitals "
                 "or an explicit inversion tensor."
@@ -322,7 +389,10 @@ class _Z2Engine:
                 gap = float("nan")
             diagnostics[bits] = {
                 "delta": delta,
-                "parity_eigenvalues": peig.detach().cpu().numpy(),
+                "parity_eigenvalues": Tensor(
+                    data=peig.detach(),
+                    dims=(IndexSpace.linear(self.n_occupied),),
+                ),
                 "commutator_error": comm,
                 "direct_gap": gap,
             }
@@ -351,8 +421,8 @@ class _Z2Engine:
         return u_svd @ vh
 
     def _wilson_wcc(
-        self, k_string: np.ndarray, loop_axis: int
-    ) -> tuple[np.ndarray, float]:
+        self, k_string: torch.Tensor, loop_axis: int
+    ) -> tuple[torch.Tensor, float]:
         ham = self.hamiltonians_at(k_string)
         energies, vectors = torch.linalg.eigh(ham)
         occupied = vectors[..., : self.n_occupied]
@@ -370,7 +440,8 @@ class _Z2Engine:
             wilson = step if wilson is None else wilson @ step
         evals = torch.linalg.eigvals(wilson)
         wcc = (torch.angle(evals) / (2 * math.pi)) % 1.0
-        return np.sort(wcc.detach().real.cpu().numpy()), min_gap
+        wcc, _ = torch.sort(wcc.real)
+        return wcc, min_gap
 
     def _plane_z2(
         self,
@@ -382,12 +453,14 @@ class _Z2Engine:
     ) -> Z2WilsonPlaneResult:
         loop_axis = (normal + 1) % 3
         sweep_axis = (normal + 2) % 3
-        sweep = np.linspace(0.0, 0.5, n_perp)
-        loop = np.linspace(0.0, 1.0, n_loop, endpoint=False)
-        wcc_list = []
+        real_dtype = self.hoppings.real.dtype
+        device = self.hoppings.device
+        sweep = torch.linspace(0.0, 0.5, n_perp, dtype=real_dtype, device=device)
+        loop = torch.arange(n_loop, dtype=real_dtype, device=device) / n_loop
+        wcc_list: list[torch.Tensor] = []
         min_gap = math.inf
         for ky in sweep:
-            k_string = np.zeros((n_loop, 3), dtype=float)
+            k_string = torch.zeros((n_loop, 3), dtype=real_dtype, device=device)
             k_string[:, normal] = trim_value
             k_string[:, sweep_axis] = ky
             k_string[:, loop_axis] = loop
@@ -398,16 +471,22 @@ class _Z2Engine:
         kramers_resolved = _kramers_pairs(
             wcc_list[0], kramers_tolerance
         ) and _kramers_pairs(wcc_list[-1], kramers_tolerance)
-        gap_pos = [_largest_gap_position(wcc) for wcc in wcc_list]
+        gap_pos = torch.tensor(
+            [_largest_gap_position(wcc) for wcc in wcc_list],
+            dtype=real_dtype,
+            device=device,
+        )
         invariant = 1
         for left, right, wcc_right in zip(gap_pos, gap_pos[1:], wcc_list[1:]):
             for pos in wcc_right:
-                invariant *= _sgng(left, right, pos)
+                invariant *= _sgng(float(left), float(right), float(pos))
+        sweep_space = IndexSpace.linear(n_perp)
+        wcc_space = IndexSpace.linear(self.n_occupied)
         return {
             "z2": 1 if invariant == -1 else 0,
-            "wcc": np.stack(wcc_list),
-            "gap_pos": np.asarray(gap_pos),
-            "sweep": sweep,
+            "wcc": Tensor(data=torch.stack(wcc_list), dims=(sweep_space, wcc_space)),
+            "gap_pos": Tensor(data=gap_pos, dims=(sweep_space,)),
+            "sweep": Tensor(data=sweep, dims=(sweep_space,)),
             "min_gap": min_gap if math.isfinite(min_gap) else float("nan"),
             "kramers_resolved": kramers_resolved,
         }
@@ -426,7 +505,11 @@ class _Z2Engine:
             planes[(normal, 0.5)] = pi
             axis_z2.append((zero["z2"], pi["z2"]))
         strong = [int((z0 + zpi) % 2) for z0, zpi in axis_z2]
-        indices = (strong[0], axis_z2[0][1], axis_z2[1][1], axis_z2[2][1])
+        if len(set(strong)) == 1:
+            strong_index = strong[0]
+        else:
+            strong_index = int(sum(strong) >= 2)
+        indices = (strong_index, axis_z2[0][1], axis_z2[1][1], axis_z2[2][1])
         min_gap = min(plane["min_gap"] for plane in planes.values())
         result: Z2WilsonResult = {
             "indices": indices,
@@ -454,6 +537,42 @@ class _Z2Engine:
             )
         return result
 
+    def check_time_reversal(self, *, stacklevel: int = 3) -> None:
+        origin = self.hoppings.new_zeros(3, dtype=self.hoppings.real.dtype)
+        energies = torch.linalg.eigvalsh(self.hamiltonians_at(origin))
+        span = float((energies.max() - energies.min()).clamp_min(1.0).item())
+        pair_tol = max(1e-6, 1e-4 * span)
+        if not _kramers_spectrum(energies, pair_tol):
+            warnings.warn(
+                "Eigenvalues at Gamma are not Kramers-degenerate; "
+                "the Hamiltonian may break time-reversal, so its Z2 indices "
+                "are not well-defined.",
+                RuntimeWarning,
+                stacklevel=stacklevel,
+            )
+        if self.time_reversal is None:
+            return
+        sample = torch.tensor(
+            [0.2, 0.3, 0.1],
+            dtype=self.hoppings.real.dtype,
+            device=self.hoppings.device,
+        )
+        ham_k = self.hamiltonians_at(sample)
+        ham_minus = self.hamiltonians_at(-sample)
+        theta = self.time_reversal
+        reconstructed = theta @ ham_k.conj() @ theta.conj().transpose(-2, -1)
+        ham_norm = torch.linalg.matrix_norm(ham_k).clamp_min(1.0)
+        error = float(
+            (torch.linalg.matrix_norm(ham_minus - reconstructed) / ham_norm).item()
+        )
+        if error > 1e-4:
+            warnings.warn(
+                f"Time-reversal check failed (relative error {error:.3e}); "
+                "Z2 indices are not well-defined.",
+                RuntimeWarning,
+                stacklevel=stacklevel,
+            )
+
 
 def _orbital_geometry(
     space,
@@ -465,63 +584,50 @@ def _orbital_geometry(
     tau = torch.zeros((n_bands, 3), dtype=dtype, device=device)
     if not isinstance(space, HilbertSpace):
         return tau, None
-    try:
-        positions = []
-        for i, state in enumerate(space.elements()):
-            offset = state.irrep_of(Offset)
-            positions.append(
-                torch.tensor(
-                    [float(c) for c in offset.to_vec()],
-                    dtype=torch.float64,
-                )
-            )
-            rebased = offset.rebase(lattice)
-            for j in range(3):
-                tau[i, j] = float(rebased.rep[j])
-        return tau, torch.stack(positions)
-    except Exception:
-        tau.zero_()
+    states = list(space.elements())
+    offsets: list[Offset | None] = []
+    missing = 0
+    for state in states:
+        try:
+            offsets.append(state.irrep_of(Offset))
+        except ValueError:
+            offsets.append(None)
+            missing += 1
+    if missing == len(states):
         return tau, None
+    if missing:
+        raise ValueError(
+            "Hilbert space has Offset labels on only some orbitals; "
+            "label every basis state or none."
+        )
+
+    positions = [None] * n_bands
+    for state, offset in zip(states, offsets):
+        assert offset is not None
+        index = space.structure[state]
+        positions[index] = torch.tensor(
+            [float(c) for c in offset.to_vec()],
+            dtype=torch.float64,
+        )
+        rebased = offset.rebase(lattice)
+        for j in range(3):
+            tau[index, j] = float(rebased.rep[j])
+    if any(item is None for item in positions):
+        raise RuntimeError("Offset labels do not cover every orbital index.")
+    return tau, torch.stack([item for item in positions if item is not None])
 
 
 def _spatial_inversion_matrix(
     space: HilbertSpace,
     center: Offset,
-    positions_cart: torch.Tensor,
-    n_bands: int,
     hoppings: torch.Tensor,
 ) -> torch.Tensor:
     inv_op = PointGroupOpr(_inversion_element()).fixpoint_at(center)
-    try:
-        return spinful_hilbert_opr_repr(inv_op, space).data.to(
-            device=hoppings.device, dtype=hoppings.dtype
-        )
-    except ValueError:
-        pass
-    elements = list(space.elements())
-    center_vec = torch.tensor([float(c) for c in center.to_vec()], dtype=torch.float64)
-    target = 2.0 * center_vec - positions_cart
-    i0 = hoppings.new_zeros((n_bands, n_bands))
-    spins: list[object | None] = []
-    for state in elements:
-        try:
-            spins.append(state.irrep_of(Spin))
-        except Exception:
-            spins.append(None)
-    used = set()
-    for i in range(n_bands):
-        delta = (positions_cart - target[i]).square().sum(dim=-1).clone()
-        for j, spin in enumerate(spins):
-            if spins[i] is not None and spin != spins[i]:
-                delta[j] = math.inf
-            if j in used:
-                delta[j] = math.inf
-        j = int(torch.argmin(delta).item())
-        if not math.isfinite(float(delta[j].item())) or float(delta[j].item()) > 1e-6:
-            raise RuntimeError("Orbital space is not closed under spatial inversion.")
-        i0[j, i] = 1
-        used.add(j)
-    return i0
+    if contains_spin(space):
+        matrix = spinful_hilbert_opr_repr(inv_op, space)
+    else:
+        matrix = hilbert_opr_repr(inv_op, space)
+    return matrix.data.to(device=hoppings.device, dtype=hoppings.dtype)
 
 
 def _build_engine(
@@ -536,22 +642,29 @@ def _build_engine(
         raise TypeError("The second dimension must be a HilbertSpace.")
     if not isinstance(bloch_hamiltonian.dims[2], HilbertSpace):
         raise TypeError("The third dimension must be a HilbertSpace.")
+    row_space = bloch_hamiltonian.dims[1]
+    if not same_rays(row_space, bloch_hamiltonian.dims[2]):
+        raise ValueError(
+            "The last two dimensions of the tensor must span the same Hilbert space."
+        )
+    bloch_hamiltonian = bloch_hamiltonian.align(-1, row_space)
 
     data = bloch_hamiltonian.data
     if data.shape[-2] != data.shape[-1]:
         raise ValueError("The Hamiltonian must be square at every momentum.")
     n_bands = int(data.shape[-1])
-    if n_occupied is None:
-        n_occupied = n_bands // 2
-    n_occupied = int(n_occupied)
-    if not 0 < n_occupied <= n_bands:
-        raise ValueError("n_occupied must lie between 1 and n_bands.")
-    if n_occupied % 2:
-        raise ValueError("Z2 requires an even occupied count (Kramers pairs).")
 
     momenta = _bloch_momenta(bloch_hamiltonian)
     if not momenta or len(momenta[0].rep) != 3:
         raise ValueError("A three-dimensional momentum grid is required.")
+
+    if n_occupied is None:
+        n_occupied = n_bands // 2
+    n_occupied = int(n_occupied)
+    if not 0 < n_occupied < n_bands:
+        raise ValueError("n_occupied must lie strictly between 0 and n_bands.")
+    if n_occupied % 2:
+        raise ValueError("Z2 requires an even occupied count (Kramers pairs).")
 
     reciprocal_lattice = momenta[0].space
     if not isinstance(reciprocal_lattice, ReciprocalLattice):
@@ -560,6 +673,11 @@ def _build_engine(
     direct_boundary = lattice.boundaries
     if not isinstance(direct_boundary, PeriodicBoundary):
         raise ValueError("The momentum grid requires periodic lattice boundaries.")
+    if not direct_boundary.basis.is_diagonal():
+        raise ValueError(
+            "Z2 Fourier interpolation requires a diagonal periodic cell; "
+            "sheared boundaries are not supported."
+        )
     dual_boundary = PeriodicBoundary(ImmutableDenseMatrix(direct_boundary.basis.T))
     grid_shape = tuple(int(n) for n in lattice.shape)
     if len(grid_shape) != 3:
@@ -590,9 +708,7 @@ def _build_engine(
             raise ValueError(
                 f"Duplicate or incomplete momentum quotient representative {key}."
             )
-        index = tuple(
-            int(i) for i in np.unravel_index(canonical_position[key], grid_shape)
-        )
+        index = _unravel_index(canonical_position[key], grid_shape)
         if index in seen:
             raise ValueError(f"Duplicate momentum grid point {index}.")
         seen.add(index)
@@ -614,16 +730,24 @@ def _build_engine(
     inversion_hoppings = None
     inversion_i0 = None
     inversion_center_vec = None
+    inversion_error: Exception | None = None
     if inversion is not None:
-        if inversion.rank() != 3 or inversion.data.shape != data.shape:
+        if inversion.rank() != 3:
+            raise ValueError("inversion must match bloch_hamiltonian's rank and shape.")
+        if not same_rays(inversion.dims[1], row_space) or not same_rays(
+            inversion.dims[2], row_space
+        ):
+            raise ValueError(
+                "inversion band axes must span the Hamiltonian Hilbert space."
+            )
+        inversion = inversion.align(-2, row_space).align(-1, row_space)
+        if inversion.data.shape != data.shape:
             raise ValueError("inversion must match bloch_hamiltonian's rank and shape.")
         inv_grid = inversion.data.new_zeros((*grid_shape, n_bands, n_bands))
         for sector, momentum in enumerate(momenta):
             integer_rep = ImmutableDenseMatrix(direct_boundary.basis.T @ momentum.rep)
             key = _rep_key(dual_boundary.wrap(integer_rep))
-            index = tuple(
-                int(i) for i in np.unravel_index(canonical_position[key], grid_shape)
-            )
+            index = _unravel_index(canonical_position[key], grid_shape)
             inv_grid[index] = inversion.data[sector]
         inversion_hoppings = torch.fft.ifftn(inv_grid, dim=(0, 1, 2))
     elif isinstance(space, HilbertSpace) and positions_cart is not None:
@@ -645,15 +769,14 @@ def _build_engine(
         else:
             center = _as_inversion_center(inversion_center, lattice)
         try:
-            inversion_i0 = _spatial_inversion_matrix(
-                space, center, positions_cart, n_bands, hoppings
-            )
+            inversion_i0 = _spatial_inversion_matrix(space, center, hoppings)
             inversion_center_vec = torch.tensor(
                 [float(c) for c in center.to_vec()], dtype=torch.float64
             )
-        except Exception:
+        except (RuntimeError, ValueError) as exc:
             inversion_i0 = None
             inversion_center_vec = None
+            inversion_error = exc
 
     return _Z2Engine(
         hoppings=hoppings,
@@ -668,6 +791,10 @@ def _build_engine(
         inversion_i0=inversion_i0,
         inversion_center_vec=inversion_center_vec,
         positions_cart=positions_cart,
+        inversion_error=inversion_error,
+        time_reversal=_time_reversal_matrix(space, hoppings)
+        if isinstance(space, HilbertSpace)
+        else None,
     )
 
 
@@ -760,11 +887,13 @@ def z2_indices(
     - ``method="wilson"`` computes hybrid Wannier charge centers on the six
       TRIM planes \(k_i=0\) and \(k_i=1/2\). The strong index is
       \(\nu_0=\nu(k_i=0)+\nu(k_i=\pi)\bmod 2\) and the weak indices are the
-      three \(k_i=\pi\) plane invariants.
+      three \(k_i=\pi\) plane invariants. If the three axes disagree on
+      \(\nu_0\), the majority vote is returned.
 
     The Hamiltonian is Fourier-interpolated from the supplied mesh, so TRIM
     and Wilson strings need not coincide with sampled \(k\)-points. This is
-    the construction used for odd diamond meshes such as \(27^3\).
+    the construction used for odd diamond meshes such as \(27^3\). The
+    periodic cell must be diagonal in the primitive basis.
 
     Parameters
     ----------
@@ -772,15 +901,17 @@ def z2_indices(
         Rank-3 Hermitian [`Tensor`][qten.linalg.tensors.Tensor] with dims
         ``(MomentumSpace, HilbertSpace, HilbertSpace)``, or with a
         [`MomentumBlockSpace`][qten.symbolics.state_space.MomentumBlockSpace]
-        whose left momenta form a complete 3-D reciprocal quotient. The last
-        two axes are square Bloch-Hamiltonian matrices.
+        of diagonal \((k,k)\) blocks whose momenta form a complete 3-D
+        reciprocal quotient. The last two axes are square Bloch-Hamiltonian
+        matrices and must span the same Hilbert space up to ray ordering.
     n_occupied : int | None, optional
         Number of lowest-energy bands defining the occupied subspace. It must
-        be even and lie between 1 and the total band count inclusive.
+        be even and lie strictly between zero and the total band count.
         Defaults to half the bands using integer division.
     method : {"auto", "parity", "wilson", "both"}, optional
         Numerical construction. ``"auto"`` tries Fu--Kane parity and falls
-        back to Wilson loops if inversion cannot be resolved. Defaults to
+        back to Wilson loops if inversion cannot be resolved
+        (`RuntimeError`). ``"both"`` requires parity to succeed. Defaults to
         ``"auto"``.
     inversion : Tensor | None, optional
         Optional rank-3 inversion tensor with the same shape as
@@ -818,11 +949,14 @@ def z2_indices(
         - ``"method"``: the construction that produced those indices.
 
         For ``method="parity"`` the mapping also contains Fu--Kane
-        ``"parity_products"`` at each TRIM, per-TRIM ``"diagnostics"``, and
-        ``"direct_gap"``.
+        ``"parity_products"`` at each TRIM, per-TRIM ``"diagnostics"``
+        (including a labeled ``"parity_eigenvalues"``
+        [`Tensor`][qten.linalg.tensors.Tensor]), and ``"direct_gap"``.
 
-        For ``method="wilson"`` it contains hybrid-Wannier ``"planes"``,
-        per-axis plane invariants ``"axis_z2"``, and ``"min_gap"``.
+        For ``method="wilson"`` it contains hybrid-Wannier ``"planes"`` whose
+        ``"wcc"``, ``"gap_pos"``, and ``"sweep"`` values are labeled
+        [`Tensor`][qten.linalg.tensors.Tensor] objects, per-axis plane
+        invariants ``"axis_z2"``, and ``"min_gap"``.
 
         For ``method="both"`` it contains both ``"parity"`` and ``"wilson"``
         sub-results; ``"indices"`` follows the parity values.
@@ -835,19 +969,22 @@ def z2_indices(
     ValueError
         If ``method`` is unsupported; the input is not a rank-3 square Bloch
         Hamiltonian; ``n_occupied`` is invalid; the momentum space is not
-        three-dimensional and periodic; or its points do not form a unique
-        complete reciprocal quotient.
+        three-dimensional and periodic with a diagonal cell; a
+        `MomentumBlockSpace` contains off-diagonal \((k,k')\) blocks; or
+        momentum points do not form a unique complete reciprocal quotient.
     RuntimeError
-        For ``method="parity"``, if inversion cannot be constructed or is not
-        resolved at a TRIM.
+        For ``method="parity"`` or ``method="both"``, if inversion cannot be
+        constructed or is not resolved at a TRIM.
 
     Warns
     -----
     RuntimeWarning
         If the sampled minimum direct gap is no larger than ``gap_tolerance``;
         if ``method="auto"`` falls back from parity to Wilson loops; if the
-        three Wilson axes disagree on \(\nu_0\); if Kramers pairing of Wannier
-        centers is unresolved; or if parity and Wilson indices disagree.
+        three Wilson axes disagree on \(\nu_0\) (majority vote is used); if
+        Kramers pairing of Wannier centers is unresolved; if parity and
+        Wilson indices disagree; or if the sampled spectrum is not
+        time-reversal / Kramers consistent.
 
     Notes
     -----
@@ -880,15 +1017,16 @@ def z2_indices(
         raise ValueError("method must be 'auto', 'parity', 'wilson', or 'both'.")
 
     engine = _build_engine(bloch_hamiltonian, n_occupied, inversion, inversion_center)
+    engine.check_time_reversal(stacklevel=2)
     parity_result: Z2ParityResult | None = None
     wilson_result: Z2WilsonResult | None = None
 
-    if method_name in {"auto", "parity", "both"}:
+    if method_name in {"parity", "both"}:
+        parity_result = engine.run_parity(parity_tolerance)
+    elif method_name == "auto":
         try:
             parity_result = engine.run_parity(parity_tolerance)
-        except Exception as exc:
-            if method_name == "parity":
-                raise
+        except RuntimeError as exc:
             warnings.warn(
                 f"Parity method unavailable ({exc}). Falling back to Wilson loops.",
                 RuntimeWarning,

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -459,9 +459,7 @@ def _two_site_bonding_insulator(shape: tuple[int, int, int] = (4, 4, 4)) -> Tens
     )
     k_space = brillouin_zone(lattice.dual)
     site_a = Offset(rep=ImmutableDenseMatrix([0, 0, 0]), space=lattice)
-    site_b = Offset(
-        rep=ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0]), space=lattice
-    )
+    site_b = Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0]), space=lattice)
     band_space = HilbertSpace.new(
         [
             U1Basis.new(site_a, Spin.up),
@@ -563,6 +561,49 @@ def test_z2_both_requires_parity():
         )
 
 
+def test_z2_parity_pairs_inversion_by_momentum_labels():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
+    k_space = hamiltonian.dims[0]
+    gauged_h_blocks = []
+    gauged_i_blocks = []
+    for sector, momentum in enumerate(k_space.elements()):
+        kx, ky, kz = (float(momentum.rep[i]) for i in range(3))
+        theta = 2.0 * math.pi * (kx + 2.0 * ky + 4.0 * kz)
+        phases = torch.exp(1j * theta * torch.arange(1, 5, dtype=torch.float64)).to(
+            torch.complex128
+        )
+        unitary = torch.diag(phases)
+        gauged_h_blocks.append(
+            unitary @ hamiltonian.data[sector] @ unitary.conj().transpose(-2, -1)
+        )
+        gauged_i_blocks.append(
+            unitary @ inversion.data[sector] @ unitary.conj().transpose(-2, -1)
+        )
+    gauged_h = Tensor(data=torch.stack(gauged_h_blocks), dims=hamiltonian.dims)
+    gauged_i = Tensor(data=torch.stack(gauged_i_blocks), dims=inversion.dims)
+
+    reversed_momenta = tuple(reversed(k_space.elements()))
+    reordered_space = MomentumSpace(
+        OrderedDict((momentum, i) for i, momentum in enumerate(reversed_momenta))
+    )
+    source_index = k_space.structure
+    reordered_inversion = Tensor(
+        data=torch.stack(
+            [gauged_i.data[source_index[momentum]] for momentum in reversed_momenta]
+        ),
+        dims=(reordered_space, inversion.dims[1], inversion.dims[2]),
+    )
+
+    result = z2_indices(
+        gauged_h,
+        n_occupied=2,
+        inversion=reordered_inversion,
+        method="parity",
+    )
+
+    assert result["indices"] == (1, 0, 0, 0)
+
+
 def test_z2_parity_aligns_reordered_band_axes():
     hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
     reference = z2_indices(
@@ -591,9 +632,7 @@ def test_z2_parity_aligns_reordered_band_axes():
 def test_z2_parity_returns_labeled_tensors():
     hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0)
 
-    parity = z2_indices(
-        hamiltonian, n_occupied=2, inversion=inversion, method="parity"
-    )
+    parity = z2_indices(hamiltonian, n_occupied=2, inversion=inversion, method="parity")
     eigenvalues = next(iter(parity["diagnostics"].values()))["parity_eigenvalues"]
     assert isinstance(eigenvalues, Tensor)
     assert eigenvalues.data.shape == (2,)
@@ -627,7 +666,9 @@ def test_z2_accepts_diagonal_momentum_block_space():
     hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
     momenta = tuple(hamiltonian.dims[0].elements())
     pair_space = MomentumBlockSpace(
-        structure=OrderedDict(((momentum, momentum), i) for i, momentum in enumerate(momenta))
+        structure=OrderedDict(
+            ((momentum, momentum), i) for i, momentum in enumerate(momenta)
+        )
     )
     blocked = Tensor(
         data=hamiltonian.data,

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -290,9 +290,7 @@ def _pauli():
     return identity, sigma_x, sigma_y, sigma_z
 
 
-def _wilson_dirac_hamiltonian(
-    mass: float, shape: tuple[int, ...] = (4, 4, 4)
-):
+def _wilson_dirac_hamiltonian(mass: float, shape: tuple[int, ...] = (4, 4, 4)):
     dimension = len(shape)
     lattice = Lattice(
         basis=ImmutableDenseMatrix.eye(dimension),

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -7,10 +7,16 @@ import torch
 from sympy import ImmutableDenseMatrix
 
 from qten.geometries.boundary import PeriodicBoundary
-from qten.geometries.spatials import Lattice
+from qten.geometries.spatials import Lattice, Offset
 from qten.linalg.tensors import Tensor
+from qten.phys import Spin
 from qten.symbolics.hilbert_space import HilbertSpace, U1Basis
-from qten.symbolics.state_space import IndexSpace, MomentumSpace, brillouin_zone
+from qten.symbolics.state_space import (
+    IndexSpace,
+    MomentumBlockSpace,
+    MomentumSpace,
+    brillouin_zone,
+)
 from qten.topology import (
     berry_curvature,
     chern_number,
@@ -380,6 +386,13 @@ def test_z2_rejects_odd_occupied_count():
         z2_indices(hamiltonian, n_occupied=1, inversion=inversion, method="parity")
 
 
+def test_z2_rejects_full_occupation():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
+
+    with pytest.raises(ValueError, match="strictly between"):
+        z2_indices(hamiltonian, n_occupied=4, inversion=inversion, method="parity")
+
+
 def test_z2_rejects_invalid_method():
     hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
 
@@ -433,3 +446,215 @@ def test_z2_auto_falls_back_to_wilson_without_inversion():
 
     assert result["method"] == "wilson"
     assert result["indices"] == (1, 0, 0, 0)
+
+
+def _two_site_bonding_insulator(shape: tuple[int, int, int] = (4, 4, 4)) -> Tensor:
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(3),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(*shape)),
+        unit_cell={
+            "A": ImmutableDenseMatrix([0, 0, 0]),
+            "B": ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0]),
+        },
+    )
+    k_space = brillouin_zone(lattice.dual)
+    site_a = Offset(rep=ImmutableDenseMatrix([0, 0, 0]), space=lattice)
+    site_b = Offset(
+        rep=ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0]), space=lattice
+    )
+    band_space = HilbertSpace.new(
+        [
+            U1Basis.new(site_a, Spin.up),
+            U1Basis.new(site_a, Spin.down),
+            U1Basis.new(site_b, Spin.up),
+            U1Basis.new(site_b, Spin.down),
+        ]
+    )
+    hopping = torch.zeros((4, 4), dtype=torch.complex128)
+    hopping[0, 2] = hopping[2, 0] = 1.0
+    hopping[1, 3] = hopping[3, 1] = 1.0
+    return Tensor(
+        data=hopping.expand(k_space.dim, -1, -1).clone(),
+        dims=(k_space, band_space, band_space),
+    )
+
+
+def test_z2_parity_assembles_inversion_from_offset_labels():
+    hamiltonian = _two_site_bonding_insulator()
+
+    result = z2_indices(hamiltonian, n_occupied=2, method="parity")
+
+    assert result["method"] == "parity"
+    assert result["indices"] == (0, 0, 0, 0)
+    assert result["direct_gap"] == pytest.approx(2.0)
+
+
+def test_z2_auto_uses_offset_assembled_parity():
+    hamiltonian = _two_site_bonding_insulator()
+
+    result = z2_indices(hamiltonian, n_occupied=2)
+
+    assert result["method"] == "parity"
+    assert result["indices"] == (0, 0, 0, 0)
+
+
+def test_z2_parity_on_odd_mesh_interpolates_trim():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(3, 3, 3))
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="parity",
+    )
+
+    assert result["indices"] == (1, 0, 0, 0)
+    assert result["direct_gap"] > 0.1
+
+
+def test_z2_wilson_indices_of_weak_ti():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(0.0)
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="wilson",
+        n_loop=16,
+        n_perp=9,
+    )
+
+    assert result["method"] == "wilson"
+    assert result["indices"] == (0, 1, 1, 1)
+
+
+def test_z2_rejects_sheared_periodic_cell():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(3),
+        boundaries=PeriodicBoundary(
+            ImmutableDenseMatrix([[2, 1, 0], [0, 2, 0], [0, 0, 2]])
+        ),
+        unit_cell={"r": ImmutableDenseMatrix.zeros(3, 1)},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    band_space = HilbertSpace.new(
+        U1Basis(coef=sy.Integer(1), base=(("band", i),)) for i in range(4)
+    )
+    identity = torch.eye(4, dtype=torch.complex128)
+    hamiltonian = Tensor(
+        data=identity.expand(k_space.dim, -1, -1).clone(),
+        dims=(k_space, band_space, band_space),
+    )
+
+    with pytest.raises(ValueError, match="diagonal periodic cell"):
+        z2_indices(hamiltonian, n_occupied=2, method="wilson")
+
+
+def test_z2_both_requires_parity():
+    hamiltonian, _inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
+
+    with pytest.raises(RuntimeError, match="Cannot build inversion"):
+        z2_indices(
+            hamiltonian,
+            n_occupied=2,
+            method="both",
+            n_loop=8,
+            n_perp=5,
+        )
+
+
+def test_z2_parity_aligns_reordered_band_axes():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
+    reference = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="parity",
+    )["indices"]
+    order = [1, 0, 3, 2]
+    reordered_columns = hamiltonian.dims[2][order]
+    reordered = Tensor(
+        data=hamiltonian.data[..., order],
+        dims=(hamiltonian.dims[0], hamiltonian.dims[1], reordered_columns),
+    )
+
+    result = z2_indices(
+        reordered,
+        n_occupied=2,
+        inversion=inversion,
+        method="parity",
+    )
+
+    assert result["indices"] == reference
+
+
+def test_z2_parity_returns_labeled_tensors():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0)
+
+    parity = z2_indices(
+        hamiltonian, n_occupied=2, inversion=inversion, method="parity"
+    )
+    eigenvalues = next(iter(parity["diagnostics"].values()))["parity_eigenvalues"]
+    assert isinstance(eigenvalues, Tensor)
+    assert eigenvalues.data.shape == (2,)
+
+    wilson = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="wilson",
+        n_loop=16,
+        n_perp=9,
+    )
+    plane = next(iter(wilson["planes"].values()))
+    assert isinstance(plane["wcc"], Tensor)
+    assert isinstance(plane["gap_pos"], Tensor)
+    assert isinstance(plane["sweep"], Tensor)
+    assert plane["wcc"].data.shape[0] == 9
+    assert plane["wcc"].data.shape[1] == 2
+
+
+def test_z2_warns_when_time_reversal_is_broken():
+    hamiltonian = _two_site_bonding_insulator()
+    zeeman = torch.diag(torch.tensor([0.3, -0.3, 0.3, -0.3], dtype=torch.complex128))
+    broken = Tensor(data=hamiltonian.data + zeeman, dims=hamiltonian.dims)
+
+    with pytest.warns(RuntimeWarning, match="Kramers-degenerate|Time-reversal"):
+        z2_indices(broken, n_occupied=2, method="parity")
+
+
+def test_z2_accepts_diagonal_momentum_block_space():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
+    momenta = tuple(hamiltonian.dims[0].elements())
+    pair_space = MomentumBlockSpace(
+        structure=OrderedDict(((momentum, momentum), i) for i, momentum in enumerate(momenta))
+    )
+    blocked = Tensor(
+        data=hamiltonian.data,
+        dims=(pair_space, hamiltonian.dims[1], hamiltonian.dims[2]),
+    )
+    inversion_blocked = Tensor(data=inversion.data, dims=blocked.dims)
+
+    result = z2_indices(
+        blocked, n_occupied=2, inversion=inversion_blocked, method="parity"
+    )
+
+    assert result["indices"] == (1, 0, 0, 0)
+
+
+def test_z2_rejects_off_diagonal_momentum_blocks():
+    hamiltonian, _inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
+    momenta = tuple(hamiltonian.dims[0].elements())
+    pairs = tuple(
+        (momenta[i], momenta[(i + 1) % len(momenta)]) for i in range(len(momenta))
+    )
+    pair_space = MomentumBlockSpace(
+        structure=OrderedDict((pair, i) for i, pair in enumerate(pairs))
+    )
+    blocked = Tensor(
+        data=hamiltonian.data,
+        dims=(pair_space, hamiltonian.dims[1], hamiltonian.dims[2]),
+    )
+
+    with pytest.raises(ValueError, match="diagonal momentum-block"):
+        z2_indices(blocked, n_occupied=2, method="wilson")

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import math
 
 import pytest
 import sympy as sy
@@ -15,6 +16,7 @@ from qten.topology import (
     chern_number,
     fubini_study_metric,
     quantum_geometric_tensor,
+    z2_indices,
 )
 
 
@@ -272,3 +274,162 @@ def test_quantum_geometry_supports_one_and_three_dimensions(sizes):
 
     with pytest.raises(ValueError, match="two-dimensional"):
         chern_number(hamiltonian, 1)
+
+
+def _pauli():
+    identity = torch.eye(2, dtype=torch.complex128)
+    sigma_x = torch.tensor([[0.0, 1.0], [1.0, 0.0]], dtype=torch.complex128)
+    sigma_y = torch.tensor([[0.0, -1.0j], [1.0j, 0.0]], dtype=torch.complex128)
+    sigma_z = torch.tensor([[1.0, 0.0], [0.0, -1.0]], dtype=torch.complex128)
+    return identity, sigma_x, sigma_y, sigma_z
+
+
+def _wilson_dirac_hamiltonian(mass: float, shape: tuple[int, int, int] = (4, 4, 4)):
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(3),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(*shape)),
+        unit_cell={"r": ImmutableDenseMatrix.zeros(3, 1)},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    band_space = HilbertSpace.new(
+        U1Basis(coef=sy.Integer(1), base=(("band", orbital, spin),))
+        for orbital in range(2)
+        for spin in range(2)
+    )
+    identity, sigma_x, sigma_y, sigma_z = _pauli()
+    beta = torch.kron(sigma_z, identity)
+    alpha_x = torch.kron(sigma_x, sigma_x)
+    alpha_y = torch.kron(sigma_x, sigma_y)
+    alpha_z = torch.kron(sigma_x, sigma_z)
+    blocks = []
+    for momentum in k_space.elements():
+        kx = 2.0 * math.pi * float(momentum.rep[0])
+        ky = 2.0 * math.pi * float(momentum.rep[1])
+        kz = 2.0 * math.pi * float(momentum.rep[2])
+        mass_term = mass + math.cos(kx) + math.cos(ky) + math.cos(kz)
+        blocks.append(
+            mass_term * beta
+            + math.sin(kx) * alpha_x
+            + math.sin(ky) * alpha_y
+            + math.sin(kz) * alpha_z
+        )
+    hamiltonian = Tensor(
+        data=torch.stack(blocks),
+        dims=(k_space, band_space, band_space),
+    )
+    inversion = Tensor(
+        data=beta.expand(hamiltonian.data.shape[0], -1, -1).clone(),
+        dims=hamiltonian.dims,
+    )
+    return hamiltonian, inversion
+
+
+@pytest.mark.parametrize(
+    ("mass", "indices"),
+    [
+        (-2.0, (1, 0, 0, 0)),
+        (-4.0, (0, 0, 0, 0)),
+        (0.0, (0, 1, 1, 1)),
+    ],
+)
+def test_z2_parity_indices_of_wilson_dirac_phases(mass, indices):
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(mass)
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="parity",
+    )
+
+    assert result["method"] == "parity"
+    assert result["indices"] == indices
+    assert result["direct_gap"] > 0.1
+
+
+def test_z2_auto_uses_parity_when_inversion_is_supplied():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0)
+
+    result = z2_indices(hamiltonian, n_occupied=2, inversion=inversion)
+
+    assert result["method"] == "parity"
+    assert result["indices"] == (1, 0, 0, 0)
+
+
+def test_z2_wilson_indices_agree_with_parity_for_strong_ti():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0)
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="wilson",
+        n_loop=16,
+        n_perp=9,
+    )
+
+    assert result["method"] == "wilson"
+    assert result["indices"] == (1, 0, 0, 0)
+    assert result["min_gap"] > 0.1
+
+
+def test_z2_rejects_odd_occupied_count():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0)
+
+    with pytest.raises(ValueError, match="even occupied count"):
+        z2_indices(hamiltonian, n_occupied=1, inversion=inversion, method="parity")
+
+
+def test_z2_rejects_invalid_method():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0, shape=(2, 2, 2))
+
+    with pytest.raises(ValueError, match="method must be"):
+        z2_indices(hamiltonian, 2, inversion=inversion, method="invalid")  # type: ignore[call-overload]
+
+
+def test_z2_rejects_two_dimensional_hamiltonian():
+    hamiltonian = _chern_insulator(ImmutableDenseMatrix.diag(4, 4))
+
+    with pytest.raises(ValueError, match="three-dimensional"):
+        z2_indices(hamiltonian, n_occupied=2, method="wilson")
+
+
+def test_z2_parity_requires_inversion_or_offset_labels():
+    hamiltonian, _inversion = _wilson_dirac_hamiltonian(-2.0)
+
+    with pytest.raises(RuntimeError, match="Cannot build inversion"):
+        z2_indices(hamiltonian, n_occupied=2, method="parity")
+
+
+def test_z2_both_prefers_parity_indices():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-2.0)
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="both",
+        n_loop=16,
+        n_perp=9,
+    )
+
+    assert result["method"] == "both"
+    assert result["indices"] == (1, 0, 0, 0)
+    assert result["parity"]["indices"] == (1, 0, 0, 0)
+    assert result["wilson"]["indices"] == (1, 0, 0, 0)
+
+
+def test_z2_auto_falls_back_to_wilson_without_inversion():
+    hamiltonian, _inversion = _wilson_dirac_hamiltonian(-2.0)
+
+    with pytest.warns(RuntimeWarning, match="Parity method unavailable"):
+        result = z2_indices(
+            hamiltonian,
+            n_occupied=2,
+            method="auto",
+            n_loop=16,
+            n_perp=9,
+        )
+
+    assert result["method"] == "wilson"
+    assert result["indices"] == (1, 0, 0, 0)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -290,11 +290,14 @@ def _pauli():
     return identity, sigma_x, sigma_y, sigma_z
 
 
-def _wilson_dirac_hamiltonian(mass: float, shape: tuple[int, int, int] = (4, 4, 4)):
+def _wilson_dirac_hamiltonian(
+    mass: float, shape: tuple[int, ...] = (4, 4, 4)
+):
+    dimension = len(shape)
     lattice = Lattice(
-        basis=ImmutableDenseMatrix.eye(3),
+        basis=ImmutableDenseMatrix.eye(dimension),
         boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(*shape)),
-        unit_cell={"r": ImmutableDenseMatrix.zeros(3, 1)},
+        unit_cell={"r": ImmutableDenseMatrix.zeros(dimension, 1)},
     )
     k_space = brillouin_zone(lattice.dual)
     band_space = HilbertSpace.new(
@@ -304,21 +307,19 @@ def _wilson_dirac_hamiltonian(mass: float, shape: tuple[int, int, int] = (4, 4, 
     )
     identity, sigma_x, sigma_y, sigma_z = _pauli()
     beta = torch.kron(sigma_z, identity)
-    alpha_x = torch.kron(sigma_x, sigma_x)
-    alpha_y = torch.kron(sigma_x, sigma_y)
-    alpha_z = torch.kron(sigma_x, sigma_z)
+    alphas = (
+        torch.kron(sigma_x, sigma_x),
+        torch.kron(sigma_x, sigma_y),
+        torch.kron(sigma_x, sigma_z),
+    )
     blocks = []
     for momentum in k_space.elements():
-        kx = 2.0 * math.pi * float(momentum.rep[0])
-        ky = 2.0 * math.pi * float(momentum.rep[1])
-        kz = 2.0 * math.pi * float(momentum.rep[2])
-        mass_term = mass + math.cos(kx) + math.cos(ky) + math.cos(kz)
-        blocks.append(
-            mass_term * beta
-            + math.sin(kx) * alpha_x
-            + math.sin(ky) * alpha_y
-            + math.sin(kz) * alpha_z
-        )
+        angles = [2.0 * math.pi * float(momentum.rep[i]) for i in range(dimension)]
+        mass_term = mass + sum(math.cos(angle) for angle in angles)
+        block = mass_term * beta
+        for angle, alpha in zip(angles, alphas):
+            block = block + math.sin(angle) * alpha
+        blocks.append(block)
     hamiltonian = Tensor(
         data=torch.stack(blocks),
         dims=(k_space, band_space, band_space),
@@ -400,11 +401,64 @@ def test_z2_rejects_invalid_method():
         z2_indices(hamiltonian, 2, inversion=inversion, method="invalid")  # type: ignore[call-overload]
 
 
-def test_z2_rejects_two_dimensional_hamiltonian():
-    hamiltonian = _chern_insulator(ImmutableDenseMatrix.diag(4, 4))
+def test_z2_rejects_one_dimensional_hamiltonian():
+    hamiltonian = _dimensional_hamiltonian((8,))
 
-    with pytest.raises(ValueError, match="three-dimensional"):
-        z2_indices(hamiltonian, n_occupied=2, method="wilson")
+    with pytest.raises(ValueError, match="two- or three-dimensional"):
+        z2_indices(hamiltonian, n_occupied=1, method="wilson")
+
+
+@pytest.mark.parametrize(
+    ("mass", "indices"),
+    [
+        (-1.0, (1,)),
+        (-3.0, (0,)),
+    ],
+)
+def test_z2_parity_indices_of_two_dimensional_wilson_dirac(mass, indices):
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(mass, shape=(4, 4))
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="parity",
+    )
+
+    assert result["method"] == "parity"
+    assert result["indices"] == indices
+    assert result["direct_gap"] > 0.1
+
+
+def test_z2_wilson_indices_agree_with_parity_in_two_dimensions():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-1.0, shape=(4, 4))
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="wilson",
+        n_loop=16,
+        n_perp=9,
+    )
+
+    assert result["method"] == "wilson"
+    assert result["indices"] == (1,)
+    assert result["min_gap"] > 0.1
+
+
+def test_z2_two_dimensional_odd_mesh_interpolates_trim():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-1.0, shape=(3, 3))
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="parity",
+    )
+
+    assert result["indices"] == (1,)
+    assert result["direct_gap"] > 0.1
 
 
 def test_z2_parity_requires_inversion_or_offset_labels():
@@ -432,6 +486,24 @@ def test_z2_both_prefers_parity_indices():
     assert result["wilson"]["indices"] == (1, 0, 0, 0)
 
 
+def test_z2_both_two_dimensional_quantum_spin_hall():
+    hamiltonian, inversion = _wilson_dirac_hamiltonian(-1.0, shape=(4, 4))
+
+    result = z2_indices(
+        hamiltonian,
+        n_occupied=2,
+        inversion=inversion,
+        method="both",
+        n_loop=16,
+        n_perp=9,
+    )
+
+    assert result["method"] == "both"
+    assert result["indices"] == (1,)
+    assert result["parity"]["indices"] == (1,)
+    assert result["wilson"]["indices"] == (1,)
+
+
 def test_z2_auto_falls_back_to_wilson_without_inversion():
     hamiltonian, _inversion = _wilson_dirac_hamiltonian(-2.0)
 
@@ -448,18 +520,18 @@ def test_z2_auto_falls_back_to_wilson_without_inversion():
     assert result["indices"] == (1, 0, 0, 0)
 
 
-def _two_site_bonding_insulator(shape: tuple[int, int, int] = (4, 4, 4)) -> Tensor:
+def _two_site_bonding_insulator(shape: tuple[int, ...] = (4, 4, 4)) -> Tensor:
+    dimension = len(shape)
+    zeros = ImmutableDenseMatrix.zeros(dimension, 1)
+    b_rep = ImmutableDenseMatrix([sy.Rational(1, 2)] + [0] * (dimension - 1))
     lattice = Lattice(
-        basis=ImmutableDenseMatrix.eye(3),
+        basis=ImmutableDenseMatrix.eye(dimension),
         boundaries=PeriodicBoundary(ImmutableDenseMatrix.diag(*shape)),
-        unit_cell={
-            "A": ImmutableDenseMatrix([0, 0, 0]),
-            "B": ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0]),
-        },
+        unit_cell={"A": zeros, "B": b_rep},
     )
     k_space = brillouin_zone(lattice.dual)
-    site_a = Offset(rep=ImmutableDenseMatrix([0, 0, 0]), space=lattice)
-    site_b = Offset(rep=ImmutableDenseMatrix([sy.Rational(1, 2), 0, 0]), space=lattice)
+    site_a = Offset(rep=zeros, space=lattice)
+    site_b = Offset(rep=b_rep, space=lattice)
     band_space = HilbertSpace.new(
         [
             U1Basis.new(site_a, Spin.up),
@@ -484,6 +556,16 @@ def test_z2_parity_assembles_inversion_from_offset_labels():
 
     assert result["method"] == "parity"
     assert result["indices"] == (0, 0, 0, 0)
+    assert result["direct_gap"] == pytest.approx(2.0)
+
+
+def test_z2_parity_assembles_inversion_in_two_dimensions():
+    hamiltonian = _two_site_bonding_insulator(shape=(4, 4))
+
+    result = z2_indices(hamiltonian, n_occupied=2, method="parity")
+
+    assert result["method"] == "parity"
+    assert result["indices"] == (0,)
     assert result["direct_gap"] == pytest.approx(2.0)
 
 
@@ -533,6 +615,26 @@ def test_z2_rejects_sheared_periodic_cell():
             ImmutableDenseMatrix([[2, 1, 0], [0, 2, 0], [0, 0, 2]])
         ),
         unit_cell={"r": ImmutableDenseMatrix.zeros(3, 1)},
+    )
+    k_space = brillouin_zone(lattice.dual)
+    band_space = HilbertSpace.new(
+        U1Basis(coef=sy.Integer(1), base=(("band", i),)) for i in range(4)
+    )
+    identity = torch.eye(4, dtype=torch.complex128)
+    hamiltonian = Tensor(
+        data=identity.expand(k_space.dim, -1, -1).clone(),
+        dims=(k_space, band_space, band_space),
+    )
+
+    with pytest.raises(ValueError, match="diagonal periodic cell"):
+        z2_indices(hamiltonian, n_occupied=2, method="wilson")
+
+
+def test_z2_rejects_sheared_two_dimensional_cell():
+    lattice = Lattice(
+        basis=ImmutableDenseMatrix.eye(2),
+        boundaries=PeriodicBoundary(ImmutableDenseMatrix([[2, 1], [0, 2]])),
+        unit_cell={"r": ImmutableDenseMatrix.zeros(2, 1)},
     )
     k_space = brillouin_zone(lattice.dual)
     band_space = HilbertSpace.new(


### PR DESCRIPTION
## Summary
- Split `qten.topology` into `chern` (QGT, Fubini–Study, Berry curvature, FHS Chern) and `z2`.
- Add `z2_indices` on a complete 2-D or 3-D Bloch mesh: Fourier interpolation to off-grid TRIM and Wilson strings, Fu–Kane parity from an explicit inversion tensor or Offset-assembled \(I(k)\), Wilson fallback, and labeled `Tensor` diagnostics.
- 2-D returns Kane–Mele \((\nu,)\); 3-D returns Fu–Kane \((\nu_0;\nu_1\nu_2\nu_3)\). Pair Hamiltonian and inversion by momentum labels, align Hilbert-space band axes, reject 1-D / sheared cells / odd filling, and warn on broken time-reversal.

## Test plan
- [x] `uv run pytest tests/test_topology.py`
- [x] 3-D Wilson–Dirac: strong TI `(-2)`, trivial `(-4)`, weak TI `(0)` for parity and Wilson
- [x] 2-D Wilson–Dirac: QSH `m=-1` → `(1,)`, trivial `m=-3` → `(0,)`; parity, Wilson, and `method="both"` agree
- [x] Offset-assembled inversion in 2-D and 3-D; odd meshes (`3²`, `3³`) interpolate TRIM
- [x] Reordered inversion momenta and reordered band axes still give the same indices
- [x] 1-D Hamiltonian, sheared 2-D/3-D cells, odd/full occupation, and off-diagonal `MomentumBlockSpace` raise