### PR TITLE
Enhance CI workflow by adding catalog-pg job for point-group testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,23 @@ jobs:
       - name: Run Unit Tests
         run: uv run tox -e py311
 
+  catalog-pg:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install the project
+        run: uv sync --extra cpu
+
       - name: Check point-group catalog
         run: uv run tox -e catalog-pg


### PR DESCRIPTION
This commit introduces a new job, `catalog-pg`, to the CI workflow, which runs on Ubuntu and includes steps for checking out the repository, installing the latest version of `uv`, setting up Python 3.11, and installing the project. This enhancement improves the continuous integration process by ensuring that point-group catalog tests are executed in a dedicated environment, thereby increasing the reliability of the testing framework.